### PR TITLE
fix(logbook): flight details now save to the correct daily logbook

### DIFF
--- a/lib/features/daily_logbook_detail/presentation/pages/flight_records_list_page.dart
+++ b/lib/features/daily_logbook_detail/presentation/pages/flight_records_list_page.dart
@@ -155,7 +155,11 @@ class _FlightRecordsListPageState extends State<FlightRecordsListPage> {
               const Spacer(),
               ElevatedButton.icon(
                 onPressed: () async {
-                  await Navigator.pushNamed(context, '/new-flight');
+                  await Navigator.pushNamed(
+                    context,
+                    '/new-flight',
+                    arguments: {'daily_logbook_id': _logbook?.id},
+                  );
                   // Re-fetch details after returning from add flight flow
                   if (mounted && _logbook != null) {
                     // ignore: use_build_context_synchronously

--- a/lib/features/logbook/presentation/pages/new_flight_page.dart
+++ b/lib/features/logbook/presentation/pages/new_flight_page.dart
@@ -159,7 +159,7 @@ class _NewFlightPageState extends State<NewFlightPage> {
         ),
         BlocListener<FlightBloc, FlightState>(
           listener: (context, state) {
-            if (state is LogbookIdLoaded) {
+            if (state is LogbookIdLoaded && _logbookId == null) {
               setState(() {
                 _logbookId = state.logbookId;
               });


### PR DESCRIPTION
When a user created a new daily logbook and then added a flight detail, the detail was being saved to the first logbook in the list instead of the newly created one.

Root cause: flight_records_list_page navigated to /new-flight without passing the current logbook ID. new_flight_page then called FetchLogbookId() which always returned logbooks.first from the API — the wrong logbook.Although the
page already supported receiving daily_logbook_id via args, the LogbookIdLoaded listener overwrote it.
Fix:
- Pass the current logbook ID as a route argument when navigating to /new-flight
   flight_records_list_page.dart: pasa {'daily_logbook_id': _logbook?.id} al
  navegar a /new-flight   

- Guard the LogbookIdLoaded listener so it only sets the ID if one was not already provided via route arguments, preventing the overwrite
  new_flight_page.dart: el listener de LogbookIdLoaded solo actúa si
  _logbookId == null    