### PR TITLE
fix(logbook): prevent edit mode when only logbook context is passed to new flight page

### DIFF
--- a/lib/features/logbook/presentation/pages/new_flight_page.dart
+++ b/lib/features/logbook/presentation/pages/new_flight_page.dart
@@ -60,9 +60,18 @@ class _NewFlightPageState extends State<NewFlightPage> {
   void _parseEditArguments() {
     final args = ModalRoute.of(context)?.settings.arguments;
     if (args is Map<String, dynamic> && args.isNotEmpty) {
-      _editArgs = args;
-      _isEditMode = true;
-      _prefillFromArgs();
+      // Only enter edit mode if actual flight data is present
+      final hasFlightData = args.containsKey('flight_number') ||
+          args.containsKey('detail_id') ||
+          args.containsKey('flight_real_date');
+      if (hasFlightData) {
+        _editArgs = args;
+        _isEditMode = true;
+        _prefillFromArgs();
+      } else if (args['daily_logbook_id'] != null) {
+        // Logbook context only — set the ID without entering edit mode
+        _logbookId = args['daily_logbook_id'].toString();
+      }
     }
   }
 


### PR DESCRIPTION
 ¿Qué estaba pasando?                                                              
                                                                                    
  Al abrir "Add Flight" desde una bitácora, el formulario mostraba "Edit Flight" en
  lugar de "New Flight". Esto confundía al usuario, que retrocedía antes de         
  completar el flujo — y por eso el vuelo nunca se creaba (sin POST al servidor).
                                                                                    
  Causa raíz      

  El fix anterior pasaba {'daily_logbook_id': id} como argumento de navegación a    
  new_flight_page. El método _parseEditArguments() detectaba cualquier argumento no
  vacío y activaba _isEditMode = true, cambiando el título a "Edit Flight" aunque el
   usuario estuviera creando un vuelo nuevo.

  Fix

  _parseEditArguments() ahora solo activa el modo edición si hay datos reales de    
  vuelo en los argumentos (flight_number, detail_id o flight_real_date). Cuando solo
   viene daily_logbook_id, lo usa directamente como contexto sin entrar en modo     
  edición — el título queda "New Flight" y el flujo de creación funciona
  correctamente.

Passing daily_logbook_id as a route arg was unintentionally triggering _isEditMode = true, showing 'Edit Flight' in the AppBar and confusing the user into tapping back before completing the flight creation flow.

Now _parseEditArguments only activates edit mode when actual flight data (flight_number, detail_id, or flight_real_date) is present in the args. When only daily_logbook_id is provided, it sets _logbookId directly and keeps the page in 'New Flight' mode.