### PR TITLE
Release/0.19.0

### DIFF
--- a/lib/core/injector/injector.dart
+++ b/lib/core/injector/injector.dart
@@ -73,6 +73,7 @@ import 'package:flight_hours_app/features/logbook/domain/usecases/deactivate_dai
 import 'package:flight_hours_app/features/tail_number/data/datasources/tail_number_remote_data_source.dart';
 import 'package:flight_hours_app/features/tail_number/data/repositories/tail_number_repository_impl.dart';
 import 'package:flight_hours_app/features/tail_number/domain/repositories/tail_number_repository.dart';
+import 'package:flight_hours_app/features/tail_number/domain/usecases/create_tail_number_use_case.dart';
 import 'package:flight_hours_app/features/tail_number/domain/usecases/get_tail_number_by_plate_use_case.dart';
 import 'package:flight_hours_app/features/tail_number/domain/usecases/list_tail_numbers_use_case.dart';
 import 'package:flight_hours_app/features/crew_member_type/data/datasources/crew_member_type_remote_data_source.dart';
@@ -189,6 +190,7 @@ abstract class InjectorApp {
   // Tail Number
   @Register.factory(ListTailNumbersUseCase)
   @Register.factory(GetTailNumberByPlateUseCase)
+  @Register.factory(CreateTailNumberUseCase)
   @Register.factory(TailNumberRepository, from: TailNumberRepositoryImpl)
   @Register.factory(
     TailNumberRemoteDataSource,

--- a/lib/core/injector/injector.g.dart
+++ b/lib/core/injector/injector.g.dart
@@ -123,6 +123,8 @@ class _$InjectorApp extends InjectorApp {
           (c) => ListTailNumbersUseCase(c.resolve<TailNumberRepository>()))
       ..registerFactory(
           (c) => GetTailNumberByPlateUseCase(c.resolve<TailNumberRepository>()))
+      ..registerFactory(
+          (c) => CreateTailNumberUseCase(c.resolve<TailNumberRepository>()))
       ..registerFactory<TailNumberRepository>((c) =>
           TailNumberRepositoryImpl(c.resolve<TailNumberRemoteDataSource>()))
       ..registerFactory<TailNumberRemoteDataSource>(

--- a/lib/features/logbook/presentation/pages/new_flight_page.dart
+++ b/lib/features/logbook/presentation/pages/new_flight_page.dart
@@ -61,7 +61,8 @@ class _NewFlightPageState extends State<NewFlightPage> {
     final args = ModalRoute.of(context)?.settings.arguments;
     if (args is Map<String, dynamic> && args.isNotEmpty) {
       // Only enter edit mode if actual flight data is present
-      final hasFlightData = args.containsKey('flight_number') ||
+      final hasFlightData =
+          args.containsKey('flight_number') ||
           args.containsKey('detail_id') ||
           args.containsKey('flight_real_date');
       if (hasFlightData) {

--- a/lib/features/tail_number/data/datasources/tail_number_remote_data_source.dart
+++ b/lib/features/tail_number/data/datasources/tail_number_remote_data_source.dart
@@ -7,6 +7,11 @@ import 'package:flight_hours_app/features/tail_number/data/models/tail_number_mo
 abstract class TailNumberRemoteDataSource {
   Future<List<TailNumberModel>> listTailNumbers();
   Future<TailNumberModel> getTailNumberByPlate(String plate);
+  Future<TailNumberModel> createTailNumber({
+    required String tailNumber,
+    required String aircraftModelId,
+    required String airlineId,
+  });
 }
 
 /// Implementation of [TailNumberRemoteDataSource] using Dio
@@ -41,6 +46,40 @@ class TailNumberRemoteDataSourceImpl implements TailNumberRemoteDataSource {
     final decoded = response.data;
 
     debugPrint('🔍 getTailNumberByPlate response: $decoded');
+
+    if (decoded is Map<String, dynamic>) {
+      if (decoded.containsKey('data') &&
+          decoded['data'] is Map<String, dynamic>) {
+        return TailNumberModel.fromJson(
+          decoded['data'] as Map<String, dynamic>,
+        );
+      }
+      return TailNumberModel.fromJson(decoded);
+    }
+
+    throw Exception('Unexpected response format');
+  }
+
+  @override
+  Future<TailNumberModel> createTailNumber({
+    required String tailNumber,
+    required String aircraftModelId,
+    required String airlineId,
+  }) async {
+    // POST /tail-numbers — creates a new aircraft registration.
+    // aircraft_model_id / airline_id are the obfuscated IDs from the
+    // /aircraft-models and /airlines listings, sent as-is.
+    final response = await _dio.post(
+      '/tail-numbers',
+      data: {
+        'tail_number': tailNumber,
+        'aircraft_model_id': aircraftModelId,
+        'airline_id': airlineId,
+      },
+    );
+    final decoded = response.data;
+
+    debugPrint('✅ createTailNumber response: $decoded');
 
     if (decoded is Map<String, dynamic>) {
       if (decoded.containsKey('data') &&

--- a/lib/features/tail_number/data/repositories/tail_number_repository_impl.dart
+++ b/lib/features/tail_number/data/repositories/tail_number_repository_impl.dart
@@ -42,4 +42,38 @@ class TailNumberRepositoryImpl implements TailNumberRepository {
       return Left(Failure(message: e.toString()));
     }
   }
+
+  @override
+  Future<Either<Failure, TailNumberEntity>> createTailNumber({
+    required String tailNumber,
+    required String aircraftModelId,
+    required String airlineId,
+  }) async {
+    try {
+      final result = await remoteDataSource.createTailNumber(
+        tailNumber: tailNumber,
+        aircraftModelId: aircraftModelId,
+        airlineId: airlineId,
+      );
+      return Right(result);
+    } on DioException catch (e) {
+      debugPrint('❌ createTailNumber error: ${e.message}');
+      // 409 Conflict → tail number already exists (backend MAT_AGR_ERR_03403)
+      if (e.response?.statusCode == 409) {
+        return Left(
+          Failure(
+            message: 'Esa matrícula ya existe. Búscala de nuevo para usarla.',
+          ),
+        );
+      }
+      final msg =
+          e.response?.data?['message']?.toString() ??
+          e.message ??
+          'No se pudo guardar la matrícula';
+      return Left(Failure(message: msg));
+    } catch (e) {
+      debugPrint('❌ createTailNumber unexpected: $e');
+      return Left(Failure(message: e.toString()));
+    }
+  }
 }

--- a/lib/features/tail_number/domain/repositories/tail_number_repository.dart
+++ b/lib/features/tail_number/domain/repositories/tail_number_repository.dart
@@ -6,4 +6,9 @@ import 'package:flight_hours_app/features/tail_number/domain/entities/tail_numbe
 abstract class TailNumberRepository {
   Future<Either<Failure, List<TailNumberEntity>>> listTailNumbers();
   Future<Either<Failure, TailNumberEntity>> getTailNumberByPlate(String plate);
+  Future<Either<Failure, TailNumberEntity>> createTailNumber({
+    required String tailNumber,
+    required String aircraftModelId,
+    required String airlineId,
+  });
 }

--- a/lib/features/tail_number/domain/usecases/create_tail_number_use_case.dart
+++ b/lib/features/tail_number/domain/usecases/create_tail_number_use_case.dart
@@ -1,0 +1,23 @@
+import 'package:dartz/dartz.dart';
+import 'package:flight_hours_app/core/error/failure.dart';
+import 'package:flight_hours_app/features/tail_number/domain/entities/tail_number_entity.dart';
+import 'package:flight_hours_app/features/tail_number/domain/repositories/tail_number_repository.dart';
+
+/// Use case to create a new tail number (aircraft registration)
+class CreateTailNumberUseCase {
+  final TailNumberRepository _repository;
+
+  CreateTailNumberUseCase(this._repository);
+
+  Future<Either<Failure, TailNumberEntity>> call({
+    required String tailNumber,
+    required String aircraftModelId,
+    required String airlineId,
+  }) {
+    return _repository.createTailNumber(
+      tailNumber: tailNumber,
+      aircraftModelId: aircraftModelId,
+      airlineId: airlineId,
+    );
+  }
+}

--- a/lib/features/tail_number/presentation/bloc/tail_number_bloc.dart
+++ b/lib/features/tail_number/presentation/bloc/tail_number_bloc.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flight_hours_app/core/injector/injector.dart';
 import 'package:flight_hours_app/features/aircraft_model/domain/usecases/get_aircraft_model_by_id_use_case.dart';
+import 'package:flight_hours_app/features/tail_number/domain/usecases/create_tail_number_use_case.dart';
 import 'package:flight_hours_app/features/tail_number/domain/usecases/get_tail_number_by_plate_use_case.dart';
 import 'package:flight_hours_app/features/tail_number/presentation/bloc/tail_number_event.dart';
 import 'package:flight_hours_app/features/tail_number/presentation/bloc/tail_number_state.dart';
@@ -16,14 +17,18 @@ import 'package:flight_hours_app/features/tail_number/presentation/bloc/tail_num
 class TailNumberBloc extends Bloc<TailNumberEvent, TailNumberState> {
   final GetTailNumberByPlateUseCase _getTailNumberByPlateUseCase;
   final GetAircraftModelByIdUseCase _getAircraftModelByIdUseCase;
+  final CreateTailNumberUseCase _createTailNumberUseCase;
 
   TailNumberBloc()
     : _getTailNumberByPlateUseCase =
           InjectorApp.resolve<GetTailNumberByPlateUseCase>(),
       _getAircraftModelByIdUseCase =
           InjectorApp.resolve<GetAircraftModelByIdUseCase>(),
+      _createTailNumberUseCase =
+          InjectorApp.resolve<CreateTailNumberUseCase>(),
       super(TailNumberInitial()) {
     on<SearchTailNumber>(_onSearch);
+    on<CreateTailNumber>(_onCreate);
     on<ResetTailNumber>(_onReset);
   }
 
@@ -50,6 +55,42 @@ class TailNumberBloc extends Bloc<TailNumberEvent, TailNumberState> {
             (_) => emit(
               TailNumberSuccess(plate),
             ), // Show plate even if model fails
+            (aircraftModel) =>
+                emit(TailNumberSuccess(plate, aircraftModel: aircraftModel)),
+          );
+        } else {
+          emit(TailNumberSuccess(plate));
+        }
+      },
+    );
+  }
+
+  /// Create a new tail number → on success behave like a successful search
+  /// (emit TailNumberSuccess with plate + aircraft model) so the lookup page
+  /// shows the result and the "Save Flight" button appears.
+  Future<void> _onCreate(
+    CreateTailNumber event,
+    Emitter<TailNumberState> emit,
+  ) async {
+    emit(TailNumberLoading());
+
+    final createResult = await _createTailNumberUseCase.call(
+      tailNumber: event.tailNumber,
+      aircraftModelId: event.aircraftModelId,
+      airlineId: event.airlineId,
+    );
+
+    await createResult.fold(
+      (failure) async => emit(TailNumberError(failure.message)),
+      (plate) async {
+        // Chain aircraft model fetch to show full info (same as search)
+        if (plate.aircraftModelId != null &&
+            plate.aircraftModelId!.isNotEmpty) {
+          final modelResult = await _getAircraftModelByIdUseCase.call(
+            plate.aircraftModelId!,
+          );
+          modelResult.fold(
+            (_) => emit(TailNumberSuccess(plate)),
             (aircraftModel) =>
                 emit(TailNumberSuccess(plate, aircraftModel: aircraftModel)),
           );

--- a/lib/features/tail_number/presentation/bloc/tail_number_event.dart
+++ b/lib/features/tail_number/presentation/bloc/tail_number_event.dart
@@ -31,5 +31,21 @@ class SelectTailNumber extends TailNumberEvent {
   List<Object?> get props => [id];
 }
 
+/// Event to create a new tail number (aircraft registration)
+class CreateTailNumber extends TailNumberEvent {
+  final String tailNumber;
+  final String aircraftModelId;
+  final String airlineId;
+
+  const CreateTailNumber({
+    required this.tailNumber,
+    required this.aircraftModelId,
+    required this.airlineId,
+  });
+
+  @override
+  List<Object?> get props => [tailNumber, aircraftModelId, airlineId];
+}
+
 /// Event to reset the tail number state
 class ResetTailNumber extends TailNumberEvent {}

--- a/lib/features/tail_number/presentation/pages/add_tail_number_page.dart
+++ b/lib/features/tail_number/presentation/pages/add_tail_number_page.dart
@@ -1,0 +1,361 @@
+import 'package:flight_hours_app/core/injector/injector.dart';
+import 'package:flight_hours_app/features/aircraft_model/domain/entities/aircraft_model_entity.dart';
+import 'package:flight_hours_app/features/aircraft_model/domain/usecases/list_aircraft_model_use_case.dart';
+import 'package:flight_hours_app/features/airline/domain/entities/airline_entity.dart';
+import 'package:flight_hours_app/features/airline/domain/usecases/list_airline_use_case.dart';
+import 'package:flight_hours_app/features/tail_number/presentation/bloc/tail_number_bloc.dart';
+import 'package:flight_hours_app/features/tail_number/presentation/bloc/tail_number_event.dart';
+import 'package:flight_hours_app/features/tail_number/presentation/bloc/tail_number_state.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+/// Form to create a new tail number (aircraft registration) when a plate
+/// is not found during the flight-creation flow.
+///
+/// Expects the [TailNumberBloc] to be provided by the caller (via
+/// BlocProvider.value) so that a successful creation lands back on
+/// TailNumberLookupPage as a TailNumberSuccess state.
+class AddTailNumberPage extends StatefulWidget {
+  final String initialPlate;
+
+  const AddTailNumberPage({super.key, this.initialPlate = ''});
+
+  @override
+  State<AddTailNumberPage> createState() => _AddTailNumberPageState();
+}
+
+class _AddTailNumberPageState extends State<AddTailNumberPage> {
+  static const _primary = Color(0xFF4facfe);
+  static const _accent = Color(0xFF00f2fe);
+  static const _dark = Color(0xFF1a1a2e);
+
+  final TextEditingController _plateController = TextEditingController();
+
+  List<AircraftModelEntity> _models = [];
+  List<AirlineEntity> _airlines = [];
+  String? _selectedModelId;
+  String? _selectedAirlineId;
+
+  bool _loadingLists = true;
+  String? _loadError;
+  bool _submitted = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _plateController.text = widget.initialPlate;
+    _loadLists();
+  }
+
+  @override
+  void dispose() {
+    _plateController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadLists() async {
+    setState(() {
+      _loadingLists = true;
+      _loadError = null;
+    });
+
+    final modelResult =
+        await InjectorApp.resolve<ListAircraftModelUseCase>().call();
+    final airlineResult =
+        await InjectorApp.resolve<ListAirlineUseCase>().call();
+
+    if (!mounted) return;
+
+    String? error;
+    modelResult.fold((f) => error = f.message, (list) => _models = list);
+    airlineResult.fold((f) => error = f.message, (list) => _airlines = list);
+
+    setState(() {
+      _loadingLists = false;
+      _loadError = error;
+    });
+  }
+
+  void _onSave() {
+    final plate = _plateController.text.trim();
+
+    if (plate.isEmpty || _selectedModelId == null || _selectedAirlineId == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        _snack('Completa la matrícula, el modelo y la aerolínea.'),
+      );
+      return;
+    }
+
+    setState(() => _submitted = true);
+    context.read<TailNumberBloc>().add(
+      CreateTailNumber(
+        tailNumber: plate,
+        aircraftModelId: _selectedModelId!,
+        airlineId: _selectedAirlineId!,
+      ),
+    );
+  }
+
+  SnackBar _snack(String message) => SnackBar(
+    content: Text(message),
+    backgroundColor: const Color(0xFFe17055),
+    behavior: SnackBarBehavior.floating,
+    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFF8F9FA),
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: _dark),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: const Text(
+          'Add Tail Number',
+          style: TextStyle(
+            color: _dark,
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        centerTitle: true,
+      ),
+      body: BlocListener<TailNumberBloc, TailNumberState>(
+        listener: (context, state) {
+          if (state is TailNumberSuccess) {
+            // Created successfully → back to lookup page showing the result.
+            Navigator.of(context).pop();
+          } else if (state is TailNumberError) {
+            setState(() => _submitted = false);
+            ScaffoldMessenger.of(context).showSnackBar(_snack(state.message));
+          }
+        },
+        child: SafeArea(
+          child: _loadingLists
+              ? const Center(
+                  child: CircularProgressIndicator(
+                    color: _primary,
+                    strokeWidth: 2.5,
+                  ),
+                )
+              : _loadError != null
+                  ? _buildLoadError()
+                  : _buildForm(),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLoadError() {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.error_outline_rounded,
+              color: Color(0xFFe17055),
+              size: 40,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'No se pudieron cargar las listas.\n$_loadError',
+              textAlign: TextAlign.center,
+              style: const TextStyle(color: Color(0xFF495057), height: 1.5),
+            ),
+            const SizedBox(height: 20),
+            TextButton(onPressed: _loadLists, child: const Text('Reintentar')),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildForm() {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Esta matrícula no existe. Regístrala para poder usarla en el vuelo.',
+            style: TextStyle(color: Color(0xFF6c757d), fontSize: 14, height: 1.5),
+          ),
+          const SizedBox(height: 24),
+
+          _label('Matrícula'),
+          const SizedBox(height: 8),
+          _card(
+            child: TextField(
+              controller: _plateController,
+              textCapitalization: TextCapitalization.characters,
+              maxLength: 7,
+              inputFormatters: [
+                // Letters, digits and hyphens (backend requires ^[A-Z0-9-]+$)
+                FilteringTextInputFormatter.allow(RegExp(r'[a-zA-Z0-9\-]')),
+                TextInputFormatter.withFunction(
+                  (oldValue, newValue) => newValue.copyWith(
+                    text: newValue.text.toUpperCase(),
+                  ),
+                ),
+              ],
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w500,
+                color: _dark,
+              ),
+              decoration: const InputDecoration(
+                counterText: '',
+                hintText: 'e.g. HK-1333',
+                hintStyle: TextStyle(
+                  color: Color(0xFFadb5bd),
+                  fontWeight: FontWeight.w400,
+                ),
+                prefixIcon: Icon(Icons.flight, color: _primary),
+                border: InputBorder.none,
+                contentPadding:
+                    EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+
+          _label('Modelo de aeronave'),
+          const SizedBox(height: 8),
+          _card(
+            child: DropdownButtonHideUnderline(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                child: DropdownButton<String>(
+                  isExpanded: true,
+                  value: _selectedModelId,
+                  hint: const Text('Selecciona un modelo'),
+                  icon: const Icon(Icons.arrow_drop_down, color: _primary),
+                  items: _models
+                      .map(
+                        (m) => DropdownMenuItem(
+                          value: m.id,
+                          child: Text(m.name, overflow: TextOverflow.ellipsis),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: (v) => setState(() => _selectedModelId = v),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+
+          _label('Aerolínea'),
+          const SizedBox(height: 8),
+          _card(
+            child: DropdownButtonHideUnderline(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                child: DropdownButton<String>(
+                  isExpanded: true,
+                  value: _selectedAirlineId,
+                  hint: const Text('Selecciona una aerolínea'),
+                  icon: const Icon(Icons.arrow_drop_down, color: _primary),
+                  items: _airlines
+                      .map(
+                        (a) => DropdownMenuItem(
+                          value: a.id,
+                          child: Text(a.name, overflow: TextOverflow.ellipsis),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: (v) => setState(() => _selectedAirlineId = v),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 32),
+
+          SizedBox(
+            width: double.infinity,
+            height: 50,
+            child: ElevatedButton(
+              onPressed: _submitted ? null : _onSave,
+              style: ElevatedButton.styleFrom(
+                padding: EdgeInsets.zero,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                elevation: 0,
+                backgroundColor: Colors.transparent,
+                shadowColor: Colors.transparent,
+                disabledBackgroundColor: Colors.grey[300],
+              ),
+              child: Ink(
+                decoration: BoxDecoration(
+                  gradient: _submitted
+                      ? null
+                      : const LinearGradient(colors: [_primary, _accent]),
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                child: Center(
+                  child: _submitted
+                      ? const SizedBox(
+                          width: 22,
+                          height: 22,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: Colors.white,
+                          ),
+                        )
+                      : const Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Icon(Icons.save, color: Colors.white, size: 20),
+                            SizedBox(width: 8),
+                            Text(
+                              'Guardar matrícula',
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontSize: 16,
+                                fontWeight: FontWeight.w600,
+                                letterSpacing: 0.5,
+                              ),
+                            ),
+                          ],
+                        ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _label(String text) => Text(
+    text,
+    style: const TextStyle(
+      color: _dark,
+      fontSize: 14,
+      fontWeight: FontWeight.w600,
+    ),
+  );
+
+  Widget _card({required Widget child}) => Container(
+    decoration: BoxDecoration(
+      color: Colors.white,
+      borderRadius: BorderRadius.circular(14),
+      boxShadow: [
+        BoxShadow(
+          color: Colors.black.withValues(alpha: 0.06),
+          blurRadius: 12,
+          offset: const Offset(0, 4),
+        ),
+      ],
+    ),
+    child: child,
+  );
+}

--- a/lib/features/tail_number/presentation/pages/tail_number_lookup_page.dart
+++ b/lib/features/tail_number/presentation/pages/tail_number_lookup_page.dart
@@ -2,6 +2,7 @@ import 'package:flight_hours_app/features/aircraft_model/domain/entities/aircraf
 import 'package:flight_hours_app/features/flight/domain/entities/flight_entity.dart';
 import 'package:flight_hours_app/features/logbook/domain/entities/logbook_detail_entity.dart';
 import 'package:flight_hours_app/features/tail_number/domain/entities/tail_number_entity.dart';
+import 'package:flight_hours_app/features/tail_number/presentation/pages/add_tail_number_page.dart';
 import 'package:flight_hours_app/features/tail_number/presentation/bloc/tail_number_bloc.dart';
 import 'package:flight_hours_app/features/tail_number/presentation/bloc/tail_number_event.dart';
 import 'package:flight_hours_app/features/tail_number/presentation/bloc/tail_number_state.dart';
@@ -110,9 +111,10 @@ class _TailNumberLookupPageState extends State<TailNumberLookupPage> {
                           controller: _controller,
                           textCapitalization: TextCapitalization.characters,
                           inputFormatters: [
-                            // Only allow letters (A-Z, a-z) and hyphens
+                            // Allow letters, digits and hyphens (plates like
+                            // HK-1333 need digits; backend requires ^[A-Z0-9-]+$)
                             FilteringTextInputFormatter.allow(
-                              RegExp(r'[a-zA-Z\-]'),
+                              RegExp(r'[a-zA-Z0-9\-]'),
                             ),
                             // Force uppercase
                             TextInputFormatter.withFunction(
@@ -486,47 +488,97 @@ class _TailNumberLookupPageState extends State<TailNumberLookupPage> {
 
   Widget _buildError(String message) {
     return Center(
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 40),
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.circular(20),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withValues(alpha: 0.04),
-              blurRadius: 16,
-              offset: const Offset(0, 4),
-            ),
-          ],
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 380),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 28, vertical: 32),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(20),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.04),
+                blurRadius: 16,
+                offset: const Offset(0, 4),
+              ),
+            ],
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 56,
+                height: 56,
+                decoration: BoxDecoration(
+                  color: const Color(0xFFe17055).withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: const Icon(
+                  Icons.error_outline_rounded,
+                  color: Color(0xFFe17055),
+                  size: 28,
+                ),
+              ),
+              const SizedBox(height: 14),
+              Text(
+                message,
+                style: const TextStyle(
+                  color: Color(0xFF495057),
+                  fontSize: 13.5,
+                  height: 1.5,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 18),
+              // ── Add tail number button ──
+              SizedBox(
+                width: double.infinity,
+                height: 46,
+                child: ElevatedButton.icon(
+                  onPressed: _openAddTailNumber,
+                  icon: const Icon(
+                    Icons.add,
+                    color: Color(0xFF4facfe),
+                    size: 20,
+                  ),
+                  label: const Text(
+                    'Agregar matrícula',
+                    style: TextStyle(
+                      color: Color(0xFF4facfe),
+                      fontSize: 14.5,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(
+                      0xFF4facfe,
+                    ).withValues(alpha: 0.1),
+                    elevation: 0,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(14),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Container(
-              width: 64,
-              height: 64,
-              decoration: BoxDecoration(
-                color: const Color(0xFFe17055).withValues(alpha: 0.1),
-                borderRadius: BorderRadius.circular(18),
-              ),
-              child: const Icon(
-                Icons.error_outline_rounded,
-                color: Color(0xFFe17055),
-                size: 32,
-              ),
+      ),
+    );
+  }
+
+  /// Opens the form to register a new tail number, sharing the current
+  /// TailNumberBloc so a successful creation lands back here as
+  /// TailNumberSuccess (which shows the result + "Save Flight" button).
+  void _openAddTailNumber() {
+    final bloc = context.read<TailNumberBloc>();
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder:
+            (_) => BlocProvider.value(
+              value: bloc,
+              child: AddTailNumberPage(initialPlate: _controller.text.trim()),
             ),
-            const SizedBox(height: 16),
-            Text(
-              message,
-              style: const TextStyle(
-                color: Color(0xFF495057),
-                fontSize: 14,
-                height: 1.5,
-              ),
-              textAlign: TextAlign.center,
-            ),
-          ],
-        ),
       ),
     );
   }


### PR DESCRIPTION
When a pilot enters an aircraft registration that does not exist in flightDb, the tail number lookup now shows an "Agregar matrícula" button that opens a form (plate + aircraft model + airline selectors) and creates the tail number via POST /tail-numbers. On success the flow returns to the lookup result so the flight can be saved as usual.

data/domain: createTailNumber in data source, repository (409 mapped to a friendly "already exists" message) and CreateTailNumberUseCase
bloc: CreateTailNumber event + handler, reusing existing states
ui: AddTailNumberPage form; button in lookup error state; constrain error card width for web; allow digits in the plate input (HK-1333)
Permite crear una matrícula (tail number) que no existe en flightDb
directamente desde la pantalla de matrícula al registrar un vuelo.

Si la búsqueda no encuentra la placa, aparece el botón "Agregar
matrícula" que abre un formulario (placa + modelo de aeronave +
aerolínea) y la crea vía POST /tail-numbers.
Manejo de duplicados (409) con mensaje amigable.
Fix: la placa ahora acepta dígitos (ej. HK-1333).
Ajuste de tamaño de la tarjeta de error para verse bien en web.
Sin cambios en el backend.