### PR TITLE
Release/0.20.0

### DIFF
--- a/lib/features/daily_logbook_detail/presentation/pages/daily_logbook_detail_page.dart
+++ b/lib/features/daily_logbook_detail/presentation/pages/daily_logbook_detail_page.dart
@@ -30,7 +30,9 @@ class _DailyLogbookDetailPageState extends State<DailyLogbookDetailPage> {
   // Dropdown selections
   String? _selectedCrewRole; // Captain / Copilot
   String? _selectedPilotRole; // PF / PNF / PFL / PFTO
-  String? _selectedApproachType;
+  String? _selectedApproachCategory;
+  String? _selectedApproachSubtype;
+  bool _autoland = false;
   String? _selectedFlightType;
 
   // Auto-calculated times
@@ -39,7 +41,11 @@ class _DailyLogbookDetailPageState extends State<DailyLogbookDetailPage> {
 
   final List<String> _crewRoles = ['captain', 'first officer'];
   final List<String> _pilotRoles = ['PF', 'PM', 'PFTO', 'PFL'];
-  final List<String> _approachTypes = ['APV', 'VISUAL'];
+  final List<String> _approachCategories = ['RNP', 'ILS', 'VISUAL'];
+  final Map<String, List<String>> _approachSubtypesByCategory = {
+    'RNP': ['LNAV', 'LNAV/VNAV', 'RNP AR = 0.3', 'RNP AR < 0.3'],
+    'ILS': ['CAT I', 'CAT II', 'CAT III > 175', 'CAT III < 175'],
+  };
   final List<String> _flightTypes = [
     'COMMERCIAL',
     'TRAINING',
@@ -60,7 +66,7 @@ class _DailyLogbookDetailPageState extends State<DailyLogbookDetailPage> {
   bool _hasChanges = false; // Tracks if user modified any field
 
   /// Per-field validation errors — keys match field labels (OUT, OFF, ON, IN,
-  /// PAX, Companion, CrewRole, PilotRole, ApproachType, FlightType, AirTime, BlockTime)
+  /// PAX, Companion, CrewRole, PilotRole, ApproachCategory, ApproachSubtype, FlightType, AirTime, BlockTime)
   Map<String, String> _fieldErrors = {};
 
   @override
@@ -140,9 +146,19 @@ class _DailyLogbookDetailPageState extends State<DailyLogbookDetailPage> {
       _selectedCrewRole = 'captain';
     }
 
-    // Approach type
-    if (d.approachType != null && _approachTypes.contains(d.approachType)) {
-      _selectedApproachType = d.approachType;
+    // Approach category + subtype
+    if (d.approachCategory != null &&
+        _approachCategories.contains(d.approachCategory)) {
+      _selectedApproachCategory = d.approachCategory;
+      final allowedSubtypes = _approachSubtypesByCategory[d.approachCategory];
+      if (allowedSubtypes != null &&
+          d.approachSubtype != null &&
+          allowedSubtypes.contains(d.approachSubtype)) {
+        _selectedApproachSubtype = d.approachSubtype;
+      }
+      if (d.approachCategory == 'ILS') {
+        _autoland = d.autoland ?? false;
+      }
     }
 
     // Flight type
@@ -386,22 +402,53 @@ class _DailyLogbookDetailPageState extends State<DailyLogbookDetailPage> {
                   ),
                   const SizedBox(height: 24),
 
-                  // ── Approach Type ──
+                  // ── Approach Category ──
                   _buildSectionLabel('Approach Type'),
                   const SizedBox(height: 8),
                   _buildDropdownCard(
-                    fieldKey: 'ApproachType',
+                    fieldKey: 'ApproachCategory',
                     icon: Icons.flight_land,
                     label: 'Select approach',
-                    value: _selectedApproachType,
-                    items: _approachTypes,
+                    value: _selectedApproachCategory,
+                    items: _approachCategories,
                     onChanged:
                         (v) => setState(() {
-                          _selectedApproachType = v;
+                          _selectedApproachCategory = v;
+                          _selectedApproachSubtype = null;
+                          if (v != 'ILS') _autoland = false;
                           _hasChanges = true;
-                          _fieldErrors.remove('ApproachType');
+                          _fieldErrors.remove('ApproachCategory');
+                          _fieldErrors.remove('ApproachSubtype');
                         }),
                   ),
+
+                  // ── Approach Subtype (only for RNP / ILS) ──
+                  if (_selectedApproachCategory != null &&
+                      _approachSubtypesByCategory.containsKey(
+                        _selectedApproachCategory,
+                      )) ...[
+                    const SizedBox(height: 12),
+                    _buildDropdownCard(
+                      fieldKey: 'ApproachSubtype',
+                      icon: Icons.rule,
+                      label: 'Select specific procedure',
+                      value: _selectedApproachSubtype,
+                      items:
+                          _approachSubtypesByCategory[_selectedApproachCategory]!,
+                      onChanged:
+                          (v) => setState(() {
+                            _selectedApproachSubtype = v;
+                            _hasChanges = true;
+                            _fieldErrors.remove('ApproachSubtype');
+                          }),
+                    ),
+                  ],
+
+                  // ── Autoland (only for ILS) ──
+                  if (_selectedApproachCategory == 'ILS') ...[
+                    const SizedBox(height: 12),
+                    _buildAutolandCheckbox(),
+                  ],
                   const SizedBox(height: 24),
 
                   // ── Flight Type ──
@@ -512,7 +559,9 @@ class _DailyLogbookDetailPageState extends State<DailyLogbookDetailPage> {
                 pilotRole: _detail!.pilotRole,
                 companionName: _detail!.companionName,
                 passengers: _detail!.passengers,
-                approachType: _detail!.approachType,
+                approachCategory: _detail!.approachCategory,
+                approachSubtype: _detail!.approachSubtype,
+                autoland: _detail!.autoland,
                 flightType: _detail!.flightType,
               );
               _isEditMode = true;
@@ -869,6 +918,46 @@ class _DailyLogbookDetailPageState extends State<DailyLogbookDetailPage> {
   }
 
   // ══════════════════════════════════════════════════════════════
+  //  AUTOLAND CHECKBOX — only shown when Approach Category is ILS
+  // ══════════════════════════════════════════════════════════════
+  Widget _buildAutolandCheckbox() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: const Color(0xFFe9ecef)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.05),
+            blurRadius: 10,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: CheckboxListTile(
+        value: _autoland,
+        onChanged:
+            (v) => setState(() {
+              _autoland = v ?? false;
+              _hasChanges = true;
+            }),
+        title: const Text(
+          'Autoland',
+          style: TextStyle(
+            color: Color(0xFF1a1a2e),
+            fontSize: 15,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        controlAffinity: ListTileControlAffinity.leading,
+        contentPadding: EdgeInsets.zero,
+        activeColor: const Color(0xFF4facfe),
+      ),
+    );
+  }
+
+  // ══════════════════════════════════════════════════════════════
   //  DROPDOWN CARDS — Captain/Copilot, PF/PNF
   // ══════════════════════════════════════════════════════════════
   Widget _buildDropdownCard({
@@ -1218,10 +1307,28 @@ class _DailyLogbookDetailPageState extends State<DailyLogbookDetailPage> {
       }
     }
 
-    // 8. Approach type (optional)
-    if (_selectedApproachType != null &&
-        !_approachTypes.contains(_selectedApproachType)) {
-      errors['ApproachType'] = 'Invalid: ${_approachTypes.join(", ")}';
+    // 8. Approach category + subtype + autoland (optional)
+    if (_selectedApproachCategory != null &&
+        !_approachCategories.contains(_selectedApproachCategory)) {
+      errors['ApproachCategory'] =
+          'Invalid: ${_approachCategories.join(", ")}';
+    } else {
+      final allowedSubtypes =
+          _approachSubtypesByCategory[_selectedApproachCategory];
+      if (allowedSubtypes != null) {
+        // RNP / ILS require a subtype
+        if (_selectedApproachSubtype == null ||
+            !allowedSubtypes.contains(_selectedApproachSubtype)) {
+          errors['ApproachSubtype'] =
+              'Select one of: ${allowedSubtypes.join(", ")}';
+        }
+      } else if (_selectedApproachSubtype != null) {
+        // VISUAL (or no category) must not carry a subtype
+        errors['ApproachSubtype'] = 'Not applicable for this approach type';
+      }
+    }
+    if (_autoland && _selectedApproachCategory != 'ILS') {
+      errors['ApproachCategory'] = 'Autoland only applies to ILS approaches';
     }
 
     // 9. Flight type (optional)
@@ -1312,7 +1419,9 @@ class _DailyLogbookDetailPageState extends State<DailyLogbookDetailPage> {
         airTime: _calculatedAirTime != '--:--' ? _calculatedAirTime : null,
         blockTime:
             _calculatedBlockTime != '--:--' ? _calculatedBlockTime : null,
-        approachType: _selectedApproachType,
+        approachCategory: _selectedApproachCategory,
+        approachSubtype: _selectedApproachSubtype,
+        autoland: _selectedApproachCategory == 'ILS' ? _autoland : null,
         flightType: _selectedFlightType,
       ),
     );

--- a/lib/features/logbook/data/models/logbook_detail_model.dart
+++ b/lib/features/logbook/data/models/logbook_detail_model.dart
@@ -28,7 +28,9 @@ class LogbookDetailModel extends LogbookDetailEntity {
     super.pilotRole,
     super.companionName,
     super.passengers,
-    super.approachType,
+    super.approachCategory,
+    super.approachSubtype,
+    super.autoland,
     super.flightType,
   });
 
@@ -53,7 +55,9 @@ class LogbookDetailModel extends LogbookDetailEntity {
   ///   "air_time": "00:29:00",
   ///   "block_time": "00:50:00",
   ///   "duty_time": "10:14:00",
-  ///   "approach_type": "VISUAL",
+  ///   "approach_category": "ILS",
+  ///   "approach_subtype": "CAT I",
+  ///   "autoland": false,
   ///   "flight_type": "Comercial",
   ///   "log_date": "2026-01-07T00:00:00-05:00",
   ///   "route_code": "MDE-BOG",
@@ -89,7 +93,9 @@ class LogbookDetailModel extends LogbookDetailEntity {
       pilotRole: json['pilot_role']?.toString(),
       companionName: json['companion_name']?.toString(),
       passengers: _parseInt(json['passengers']),
-      approachType: json['approach_type']?.toString(),
+      approachCategory: json['approach_category']?.toString(),
+      approachSubtype: json['approach_subtype']?.toString(),
+      autoland: json['autoland'] is bool ? json['autoland'] as bool : null,
       flightType: json['flight_type']?.toString(),
     );
   }
@@ -134,7 +140,9 @@ class LogbookDetailModel extends LogbookDetailEntity {
       if (airTime != null) 'air_time': airTime,
       if (blockTime != null) 'block_time': blockTime,
       if (dutyTime != null) 'duty_time': dutyTime,
-      if (approachType != null) 'approach_type': approachType,
+      if (approachCategory != null) 'approach_category': approachCategory,
+      if (approachSubtype != null) 'approach_subtype': approachSubtype,
+      if (autoland != null) 'autoland': autoland,
       if (flightType != null) 'flight_type': flightType,
     };
   }
@@ -160,8 +168,10 @@ class LogbookDetailModel extends LogbookDetailEntity {
     required String airTime,
     required String blockTime,
     required String dutyTime,
-    required String approachType,
+    required String approachCategory,
     required String flightType,
+    String? approachSubtype,
+    bool? autoland,
   }) {
     return {
       'flight_real_date': flightRealDate,
@@ -178,7 +188,9 @@ class LogbookDetailModel extends LogbookDetailEntity {
       'air_time': airTime,
       'block_time': blockTime,
       'duty_time': dutyTime,
-      'approach_type': approachType,
+      'approach_category': approachCategory,
+      if (approachSubtype != null) 'approach_subtype': approachSubtype,
+      if (autoland != null) 'autoland': autoland,
       'flight_type': flightType,
     };
   }
@@ -201,7 +213,9 @@ class LogbookDetailModel extends LogbookDetailEntity {
     String? airTime,
     String? blockTime,
     String? dutyTime,
-    String? approachType,
+    String? approachCategory,
+    String? approachSubtype,
+    bool? autoland,
     String? flightType,
   }) {
     final map = <String, dynamic>{
@@ -244,8 +258,14 @@ class LogbookDetailModel extends LogbookDetailEntity {
     if (dutyTime != null && dutyTime.isNotEmpty) {
       map['duty_time'] = _toHHMM(dutyTime);
     }
-    if (approachType != null && approachType.isNotEmpty) {
-      map['approach_type'] = approachType;
+    if (approachCategory != null && approachCategory.isNotEmpty) {
+      map['approach_category'] = approachCategory;
+    }
+    if (approachSubtype != null && approachSubtype.isNotEmpty) {
+      map['approach_subtype'] = approachSubtype;
+    }
+    if (autoland != null) {
+      map['autoland'] = autoland;
     }
     if (flightType != null && flightType.isNotEmpty) {
       map['flight_type'] = flightType;

--- a/lib/features/logbook/data/repositories/logbook_repository_impl.dart
+++ b/lib/features/logbook/data/repositories/logbook_repository_impl.dart
@@ -158,8 +158,10 @@ class LogbookRepositoryImpl implements LogbookRepository {
     required String airTime,
     required String blockTime,
     required String dutyTime,
-    required String approachType,
+    required String approachCategory,
     required String flightType,
+    String? approachSubtype,
+    bool? autoland,
   }) async {
     try {
       final data = LogbookDetailModel.createRequest(
@@ -177,7 +179,9 @@ class LogbookRepositoryImpl implements LogbookRepository {
         airTime: airTime,
         blockTime: blockTime,
         dutyTime: dutyTime,
-        approachType: approachType,
+        approachCategory: approachCategory,
+        approachSubtype: approachSubtype,
+        autoland: autoland,
         flightType: flightType,
       );
 
@@ -212,7 +216,9 @@ class LogbookRepositoryImpl implements LogbookRepository {
     String? airTime,
     String? blockTime,
     String? dutyTime,
-    String? approachType,
+    String? approachCategory,
+    String? approachSubtype,
+    bool? autoland,
     String? flightType,
   }) async {
     try {
@@ -232,7 +238,9 @@ class LogbookRepositoryImpl implements LogbookRepository {
         airTime: airTime,
         blockTime: blockTime,
         dutyTime: dutyTime,
-        approachType: approachType,
+        approachCategory: approachCategory,
+        approachSubtype: approachSubtype,
+        autoland: autoland,
         flightType: flightType,
       );
 

--- a/lib/features/logbook/domain/entities/logbook_detail_entity.dart
+++ b/lib/features/logbook/domain/entities/logbook_detail_entity.dart
@@ -39,7 +39,9 @@ class LogbookDetailEntity extends Equatable {
 
   // Flight details
   final int? passengers;
-  final String? approachType; // NPA, PA, APV, VISUAL
+  final String? approachCategory; // RNP, ILS, VISUAL
+  final String? approachSubtype; // e.g. LNAV, CAT I — null for VISUAL
+  final bool? autoland; // only meaningful when approachCategory is ILS
   final String? flightType; // Comercial, Training, etc.
 
   const LogbookDetailEntity({
@@ -67,7 +69,9 @@ class LogbookDetailEntity extends Equatable {
     this.pilotRole,
     this.companionName,
     this.passengers,
-    this.approachType,
+    this.approachCategory,
+    this.approachSubtype,
+    this.autoland,
     this.flightType,
   });
 
@@ -131,6 +135,17 @@ class LogbookDetailEntity extends Equatable {
     return tailNumber ?? modelName ?? 'Unknown Aircraft';
   }
 
+  /// Returns a composed approach display (e.g. "ILS · CAT III < 175 (Autoland)",
+  /// "RNP · LNAV", "VISUAL")
+  String get approachDisplay {
+    if (approachCategory == null || approachCategory!.isEmpty) return 'N/A';
+    if (approachSubtype == null || approachSubtype!.isEmpty) {
+      return approachCategory!;
+    }
+    final autolandSuffix = autoland == true ? ' (Autoland)' : '';
+    return '$approachCategory · $approachSubtype$autolandSuffix';
+  }
+
   @override
   List<Object?> get props => [
     id,
@@ -157,7 +172,9 @@ class LogbookDetailEntity extends Equatable {
     pilotRole,
     companionName,
     passengers,
-    approachType,
+    approachCategory,
+    approachSubtype,
+    autoland,
     flightType,
   ];
 }

--- a/lib/features/logbook/domain/repositories/logbook_repository.dart
+++ b/lib/features/logbook/domain/repositories/logbook_repository.dart
@@ -48,8 +48,10 @@ abstract class LogbookRepository {
     required String airTime,
     required String blockTime,
     required String dutyTime,
-    required String approachType,
+    required String approachCategory,
     required String flightType,
+    String? approachSubtype,
+    bool? autoland,
   });
 
   Future<Either<Failure, LogbookDetailEntity>> updateLogbookDetail({
@@ -69,7 +71,9 @@ abstract class LogbookRepository {
     String? airTime,
     String? blockTime,
     String? dutyTime,
-    String? approachType,
+    String? approachCategory,
+    String? approachSubtype,
+    bool? autoland,
     String? flightType,
   });
 

--- a/lib/features/logbook/domain/usecases/update_logbook_detail_use_case.dart
+++ b/lib/features/logbook/domain/usecases/update_logbook_detail_use_case.dart
@@ -27,7 +27,9 @@ class UpdateLogbookDetailUseCase {
     String? airTime,
     String? blockTime,
     String? dutyTime,
-    String? approachType,
+    String? approachCategory,
+    String? approachSubtype,
+    bool? autoland,
     String? flightType,
   }) async {
     return await _repository.updateLogbookDetail(
@@ -47,7 +49,9 @@ class UpdateLogbookDetailUseCase {
       airTime: airTime,
       blockTime: blockTime,
       dutyTime: dutyTime,
-      approachType: approachType,
+      approachCategory: approachCategory,
+      approachSubtype: approachSubtype,
+      autoland: autoland,
       flightType: flightType,
     );
   }

--- a/lib/features/logbook/presentation/bloc/logbook_bloc.dart
+++ b/lib/features/logbook/presentation/bloc/logbook_bloc.dart
@@ -393,7 +393,9 @@ class LogbookBloc extends Bloc<LogbookEvent, LogbookState> {
       airTime: event.airTime,
       blockTime: event.blockTime,
       dutyTime: event.dutyTime,
-      approachType: event.approachType,
+      approachCategory: event.approachCategory,
+      approachSubtype: event.approachSubtype,
+      autoland: event.autoland,
       flightType: event.flightType,
     );
 

--- a/lib/features/logbook/presentation/bloc/logbook_event.dart
+++ b/lib/features/logbook/presentation/bloc/logbook_event.dart
@@ -126,7 +126,9 @@ class UpdateLogbookDetailEvent extends LogbookEvent {
   final String? airTime;
   final String? blockTime;
   final String? dutyTime;
-  final String? approachType;
+  final String? approachCategory;
+  final String? approachSubtype;
+  final bool? autoland;
   final String? flightType;
 
   const UpdateLogbookDetailEvent({
@@ -143,7 +145,9 @@ class UpdateLogbookDetailEvent extends LogbookEvent {
     this.airTime,
     this.blockTime,
     this.dutyTime,
-    this.approachType,
+    this.approachCategory,
+    this.approachSubtype,
+    this.autoland,
     this.flightType,
   });
 
@@ -162,7 +166,9 @@ class UpdateLogbookDetailEvent extends LogbookEvent {
     airTime,
     blockTime,
     dutyTime,
-    approachType,
+    approachCategory,
+    approachSubtype,
+    autoland,
     flightType,
   ];
 }

--- a/lib/features/logbook/presentation/pages/logbook_page.dart
+++ b/lib/features/logbook/presentation/pages/logbook_page.dart
@@ -904,7 +904,7 @@ class _LogbookPageState extends State<LogbookPage> {
             _buildDetailRow('Aircraft', detail.aircraftDisplay),
             _buildDetailRow('Passengers', '${detail.passengers ?? 0}'),
             _buildDetailRow('Flight Type', detail.flightType ?? 'N/A'),
-            _buildDetailRow('Approach', detail.approachType ?? 'N/A'),
+            _buildDetailRow('Approach', detail.approachDisplay),
 
             const SizedBox(height: 16),
             const Text(

--- a/lib/features/login/presentation/pages/hello_employee_loginpage.dart
+++ b/lib/features/login/presentation/pages/hello_employee_loginpage.dart
@@ -527,7 +527,7 @@ class _HelloEmployeeState extends State<HelloEmployee> {
           pilotRole: flight.pilotRole,
           companionName: flight.companionName,
           passengers: flight.passengers,
-          approachType: flight.approachType,
+          approachCategory: flight.approachType,
           flightType: flight.flightType,
         );
         await Navigator.pushNamed(

--- a/lib/features/tail_number/presentation/pages/tail_number_lookup_page.dart
+++ b/lib/features/tail_number/presentation/pages/tail_number_lookup_page.dart
@@ -693,7 +693,7 @@ class _TailNumberLookupPageState extends State<TailNumberLookupPage> {
       pilotRole: flight.pilotRole,
       companionName: flight.companionName,
       passengers: flight.passengers,
-      approachType: flight.approachType,
+      approachCategory: flight.approachType,
       flightType: flight.flightType,
     );
 

--- a/test/features/logbook/data/models/logbook_detail_model_test.dart
+++ b/test/features/logbook/data/models/logbook_detail_model_test.dart
@@ -29,7 +29,9 @@ void main() {
         'air_time': '00:29:00',
         'block_time': '00:50:00',
         'duty_time': '10:14:00',
-        'approach_type': 'VISUAL',
+        'approach_category': 'ILS',
+        'approach_subtype': 'CAT I',
+        'autoland': true,
         'flight_type': 'Comercial',
         'log_date': '2026-01-07T00:00:00-05:00',
       };
@@ -58,7 +60,9 @@ void main() {
       expect(result.airTime, equals('00:29:00'));
       expect(result.blockTime, equals('00:50:00'));
       expect(result.dutyTime, equals('10:14:00'));
-      expect(result.approachType, equals('VISUAL'));
+      expect(result.approachCategory, equals('ILS'));
+      expect(result.approachSubtype, equals('CAT I'));
+      expect(result.autoland, isTrue);
       expect(result.flightType, equals('Comercial'));
     });
 
@@ -143,7 +147,8 @@ void main() {
         airTime: '00:29:00',
         blockTime: '00:50:00',
         dutyTime: '10:14:00',
-        approachType: 'VISUAL',
+        approachCategory: 'ILS',
+        approachSubtype: 'CAT I',
         flightType: 'Comercial',
       );
 
@@ -188,7 +193,7 @@ void main() {
         airTime: '00:29:00',
         blockTime: '00:50:00',
         dutyTime: '10:14:00',
-        approachType: 'VISUAL',
+        approachCategory: 'VISUAL',
         flightType: 'Comercial',
       );
 

--- a/test/features/logbook/data/repositories/logbook_repository_impl_test.dart
+++ b/test/features/logbook/data/repositories/logbook_repository_impl_test.dart
@@ -375,7 +375,7 @@ void main() {
           airTime: '00:45',
           blockTime: '01:10',
           dutyTime: '08:00',
-          approachType: 'ILS',
+          approachCategory: 'ILS',
           flightType: 'Commercial',
         );
 
@@ -415,7 +415,7 @@ void main() {
           airTime: '00:45',
           blockTime: '01:10',
           dutyTime: '08:00',
-          approachType: 'ILS',
+          approachCategory: 'ILS',
           flightType: 'C',
         );
         expect(result, isA<Left>());
@@ -444,7 +444,7 @@ void main() {
           airTime: '00:45',
           blockTime: '01:10',
           dutyTime: '08:00',
-          approachType: 'ILS',
+          approachCategory: 'ILS',
           flightType: 'C',
         );
         expect(result, isA<Left>());
@@ -477,7 +477,7 @@ void main() {
           airTime: '00:45',
           blockTime: '01:10',
           dutyTime: '08:00',
-          approachType: 'VISUAL',
+          approachCategory: 'VISUAL',
           flightType: 'Commercial',
         );
 

--- a/test/features/logbook/domain/entities/logbook_detail_entity_test.dart
+++ b/test/features/logbook/domain/entities/logbook_detail_entity_test.dart
@@ -174,7 +174,7 @@ void main() {
         pilotRole: 'PM',
       );
 
-      expect(entity.props.length, equals(26));
+      expect(entity.props.length, equals(28));
     });
   });
 }

--- a/test/features/logbook/presentation/bloc/logbook_bloc_test.dart
+++ b/test/features/logbook/presentation/bloc/logbook_bloc_test.dart
@@ -157,7 +157,7 @@ void main() {
         crewRole: 'Captain',
       );
       expect(event, isA<LogbookEvent>());
-      expect(event.props.length, equals(15));
+      expect(event.props.length, equals(17));
       expect(event.originalDetail.id, 'd1');
       expect(event.passengers, 150);
     });
@@ -950,7 +950,9 @@ void main() {
             airTime: any(named: 'airTime'),
             blockTime: any(named: 'blockTime'),
             dutyTime: any(named: 'dutyTime'),
-            approachType: any(named: 'approachType'),
+            approachCategory: any(named: 'approachCategory'),
+            approachSubtype: any(named: 'approachSubtype'),
+            autoland: any(named: 'autoland'),
             flightType: any(named: 'flightType'),
           ),
         ).thenAnswer((_) async => const Right(LogbookDetailEntity(id: 'd1')));
@@ -994,7 +996,9 @@ void main() {
             airTime: any(named: 'airTime'),
             blockTime: any(named: 'blockTime'),
             dutyTime: any(named: 'dutyTime'),
-            approachType: any(named: 'approachType'),
+            approachCategory: any(named: 'approachCategory'),
+            approachSubtype: any(named: 'approachSubtype'),
+            autoland: any(named: 'autoland'),
             flightType: any(named: 'flightType'),
           ),
         ).thenAnswer(


### PR DESCRIPTION
feat(daily_logbook_detail): redesign Approach Type selector for RNP/ILS/VISUAL

Replaces the flat 2-option Approach Type dropdown (APV/VISUAL) with a
two-step selector matching the backend's new taxonomy: pick a category
(RNP/ILS/VISUAL), then a second dropdown reveals that category's 4
specific procedures. An Autoland checkbox appears only under ILS.

Entity/model gain approachCategory, approachSubtype and autoland fields
(replacing approachType) and are threaded through the update event → bloc
→ use case → repository chain. Logbook list/detail display composes the
new fields (e.g. "ILS · CAT III < 175 (Autoland)").