### PR TITLE
Release/0.22.0

### DIFF
--- a/lib/core/injector/injector.dart
+++ b/lib/core/injector/injector.dart
@@ -57,6 +57,7 @@ import 'package:flight_hours_app/features/airline_route/data/repositories/airlin
 import 'package:flight_hours_app/features/airline_route/domain/repositories/airline_route_repository.dart';
 import 'package:flight_hours_app/features/airline_route/domain/usecases/list_airline_routes_use_case.dart';
 import 'package:flight_hours_app/features/airline_route/domain/usecases/get_airline_route_by_id_use_case.dart';
+import 'package:flight_hours_app/features/airline_route/domain/usecases/resolve_airline_route_use_case.dart';
 import 'package:flight_hours_app/features/logbook/data/datasources/logbook_remote_data_source.dart';
 import 'package:flight_hours_app/features/logbook/data/repositories/logbook_repository_impl.dart';
 import 'package:flight_hours_app/features/logbook/domain/repositories/logbook_repository.dart';
@@ -170,6 +171,7 @@ abstract class InjectorApp {
   // Airline Route
   @Register.factory(ListAirlineRoutesUseCase)
   @Register.factory(GetAirlineRouteByIdUseCase)
+  @Register.factory(ResolveAirlineRouteUseCase)
   @Register.factory(AirlineRouteRepository, from: AirlineRouteRepositoryImpl)
   @Register.factory(
     AirlineRouteRemoteDataSource,

--- a/lib/core/injector/injector.g.dart
+++ b/lib/core/injector/injector.g.dart
@@ -92,6 +92,8 @@ class _$InjectorApp extends InjectorApp {
           repository: c.resolve<AirlineRouteRepository>()))
       ..registerFactory((c) => GetAirlineRouteByIdUseCase(
           repository: c.resolve<AirlineRouteRepository>()))
+      ..registerFactory((c) => ResolveAirlineRouteUseCase(
+          repository: c.resolve<AirlineRouteRepository>()))
       ..registerFactory<AirlineRouteRepository>((c) =>
           AirlineRouteRepositoryImpl(
               remoteDataSource: c.resolve<AirlineRouteRemoteDataSource>()))

--- a/lib/features/airline_route/data/datasources/airline_route_remote_data_source.dart
+++ b/lib/features/airline_route/data/datasources/airline_route_remote_data_source.dart
@@ -16,6 +16,19 @@ abstract class AirlineRouteRemoteDataSource {
   /// Fetch a specific airline route by ID (obfuscated or UUID)
   Future<AirlineRouteModel?> getAirlineRouteById(String id);
 
+  /// Resolves the authenticated employee's airline link for an origin/
+  /// destination airport pair. If the physical route exists but isn't
+  /// linked to their airline yet, the backend auto-creates the link with
+  /// status "pending" for an admin to approve — the returned model's
+  /// `status` tells the caller which case happened.
+  ///
+  /// Returns null when no physical route is configured for that pair at all
+  /// (the admin still needs to create the route itself first).
+  Future<AirlineRouteModel?> resolveAirlineRoute({
+    required String originAirportId,
+    required String destinationAirportId,
+  });
+
   /// Activate an airline route by ID
   Future<AirlineRouteStatusResponse> activateAirlineRoute(String id);
 
@@ -106,6 +119,25 @@ class AirlineRouteRemoteDataSourceImpl implements AirlineRouteRemoteDataSource {
       }
       rethrow;
     }
+  }
+
+  @override
+  Future<AirlineRouteModel?> resolveAirlineRoute({
+    required String originAirportId,
+    required String destinationAirportId,
+  }) async {
+    // Unlike the other methods here, DioException is deliberately left to
+    // propagate (not swallowed into a null return) — the repository layer
+    // needs the real status code (404 = no route configured, vs a genuine
+    // server error) to build the right Failure for the UI.
+    final response = await _dio.post(
+      '/employees/airline-routes/resolve',
+      data: {
+        'origin_airport_id': originAirportId,
+        'destination_airport_id': destinationAirportId,
+      },
+    );
+    return _parseAirlineRouteFromMap(response.data);
   }
 
   @override

--- a/lib/features/airline_route/data/models/airline_route_model.dart
+++ b/lib/features/airline_route/data/models/airline_route_model.dart
@@ -10,8 +10,12 @@ class AirlineRouteModel extends AirlineRouteEntity {
     super.routeName,
     super.airlineName,
     super.airlineCode,
+    super.originAirportId,
     super.originAirportCode,
+    super.originOaciCode,
+    super.destinationAirportId,
     super.destinationAirportCode,
+    super.destinationOaciCode,
     super.status,
   });
 
@@ -38,11 +42,15 @@ class AirlineRouteModel extends AirlineRouteEntity {
       routeName: json['route_name']?.toString(),
       airlineName: json['airline_name']?.toString(),
       airlineCode: json['airline_code']?.toString(),
+      originAirportId: json['origin_airport_id']?.toString(),
       originAirportCode:
           (json['origin_airport_code'] ?? json['origin_iata_code'])?.toString(),
+      originOaciCode: json['origin_oaci_code']?.toString(),
+      destinationAirportId: json['destination_airport_id']?.toString(),
       destinationAirportCode:
           (json['destination_airport_code'] ?? json['destination_iata_code'])
               ?.toString(),
+      destinationOaciCode: json['destination_oaci_code']?.toString(),
       status: _parseStatus(json['status']),
     );
   }
@@ -66,8 +74,12 @@ class AirlineRouteModel extends AirlineRouteEntity {
       'route_name': routeName,
       'airline_name': airlineName,
       'airline_code': airlineCode,
+      'origin_airport_id': originAirportId,
       'origin_airport_code': originAirportCode,
+      'origin_oaci_code': originOaciCode,
+      'destination_airport_id': destinationAirportId,
       'destination_airport_code': destinationAirportCode,
+      'destination_oaci_code': destinationOaciCode,
       'status': status,
     };
   }

--- a/lib/features/airline_route/data/repositories/airline_route_repository_impl.dart
+++ b/lib/features/airline_route/data/repositories/airline_route_repository_impl.dart
@@ -54,4 +54,23 @@ class AirlineRouteRepositoryImpl implements AirlineRouteRepository {
       return Left(_handleError(e));
     }
   }
+
+  @override
+  Future<Either<Failure, AirlineRouteEntity>> resolveAirlineRoute({
+    required String originAirportId,
+    required String destinationAirportId,
+  }) async {
+    try {
+      final result = await remoteDataSource.resolveAirlineRoute(
+        originAirportId: originAirportId,
+        destinationAirportId: destinationAirportId,
+      );
+      if (result == null) {
+        return Left(Failure(message: 'Route not found', statusCode: 404));
+      }
+      return Right(result);
+    } catch (e) {
+      return Left(_handleError(e));
+    }
+  }
 }

--- a/lib/features/airline_route/domain/entities/airline_route_entity.dart
+++ b/lib/features/airline_route/domain/entities/airline_route_entity.dart
@@ -10,8 +10,13 @@ class AirlineRouteEntity extends Equatable {
   final String? routeName; // Route display name (e.g., "JFK → LAX")
   final String? airlineName; // Airline name (e.g., "Global Air")
   final String? airlineCode; // Airline code (e.g., "AV")
+  final String? originAirportId; // Origin airport ID — robust match key,
+  // unlike codes it's never null even for OACI-only airports
   final String? originAirportCode; // Origin IATA code (e.g., "JFK")
+  final String? originOaciCode; // Origin OACI code (e.g., "KJFK")
+  final String? destinationAirportId; // Destination airport ID
   final String? destinationAirportCode; // Destination IATA code (e.g., "LAX")
+  final String? destinationOaciCode; // Destination OACI code
   final String? status; // "active", "inactive", "pending"
 
   const AirlineRouteEntity({
@@ -22,8 +27,12 @@ class AirlineRouteEntity extends Equatable {
     this.routeName,
     this.airlineName,
     this.airlineCode,
+    this.originAirportId,
     this.originAirportCode,
+    this.originOaciCode,
+    this.destinationAirportId,
     this.destinationAirportCode,
+    this.destinationOaciCode,
     this.status,
   });
 
@@ -79,8 +88,12 @@ class AirlineRouteEntity extends Equatable {
     routeName,
     airlineName,
     airlineCode,
+    originAirportId,
     originAirportCode,
+    originOaciCode,
+    destinationAirportId,
     destinationAirportCode,
+    destinationOaciCode,
     status,
   ];
 }

--- a/lib/features/airline_route/domain/repositories/airline_route_repository.dart
+++ b/lib/features/airline_route/domain/repositories/airline_route_repository.dart
@@ -9,4 +9,11 @@ abstract class AirlineRouteRepository {
 
   /// Get a specific airline route by ID (supports obfuscated or UUID)
   Future<Either<Failure, AirlineRouteEntity>> getAirlineRouteById(String id);
+
+  /// Resolves (or auto-requests as pending) the authenticated employee's
+  /// airline link for an origin/destination airport pair.
+  Future<Either<Failure, AirlineRouteEntity>> resolveAirlineRoute({
+    required String originAirportId,
+    required String destinationAirportId,
+  });
 }

--- a/lib/features/airline_route/domain/usecases/resolve_airline_route_use_case.dart
+++ b/lib/features/airline_route/domain/usecases/resolve_airline_route_use_case.dart
@@ -1,0 +1,19 @@
+import 'package:dartz/dartz.dart';
+import 'package:flight_hours_app/core/error/failure.dart';
+import 'package:flight_hours_app/features/airline_route/domain/entities/airline_route_entity.dart';
+import 'package:flight_hours_app/features/airline_route/domain/repositories/airline_route_repository.dart';
+
+class ResolveAirlineRouteUseCase {
+  final AirlineRouteRepository repository;
+  ResolveAirlineRouteUseCase({required this.repository});
+
+  Future<Either<Failure, AirlineRouteEntity>> call({
+    required String originAirportId,
+    required String destinationAirportId,
+  }) async {
+    return await repository.resolveAirlineRoute(
+      originAirportId: originAirportId,
+      destinationAirportId: destinationAirportId,
+    );
+  }
+}

--- a/lib/features/daily_logbook_detail/presentation/pages/daily_logbook_detail_page.dart
+++ b/lib/features/daily_logbook_detail/presentation/pages/daily_logbook_detail_page.dart
@@ -205,6 +205,30 @@ class _DailyLogbookDetailPageState extends State<DailyLogbookDetailPage> {
     return time;
   }
 
+  /// Date shown under the AppBar title — prefers the flight's own saved date
+  /// (already captured on the New Flight screen) over the parent logbook's
+  /// date, so it's correct even when this page is reached without a
+  /// `logbook` argument (e.g. right after creating a flight).
+  String? get _titleDate {
+    final date = _detail?.flightRealDate ?? _logbook?.logDate;
+    if (date == null) return null;
+    const months = [
+      'January',
+      'February',
+      'March',
+      'April',
+      'May',
+      'June',
+      'July',
+      'August',
+      'September',
+      'October',
+      'November',
+      'December',
+    ];
+    return '${months[date.month - 1]} ${date.day}, ${date.year}';
+  }
+
   /// Format HH:MM to HH:MM:SS for API
   /// Converts time for API: normalizes aviation 24+ hours to 00-23 and appends seconds
   String _formatTimeForApi(String time) {
@@ -307,21 +331,33 @@ class _DailyLogbookDetailPageState extends State<DailyLogbookDetailPage> {
             ),
           ),
           title: Column(
+            mainAxisSize: MainAxisSize.min,
             children: [
               Text(
-                _isEditMode ? 'Daily Logbook Detail' : 'Detail',
+                _isEditMode
+                    ? 'Flight ${_detail?.flightNumber ?? '--'}'
+                    : 'Detail',
                 style: const TextStyle(
                   color: Color(0xFF1a1a2e),
                   fontSize: 20,
                   fontWeight: FontWeight.bold,
                 ),
               ),
-              if (_logbook != null)
+              if (_isEditMode)
                 Text(
-                  _logbook!.fullFormattedDate,
+                  _detail!.routeDisplay,
+                  style: const TextStyle(
+                    color: Color(0xFF4facfe),
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              if (_titleDate != null)
+                Text(
+                  _titleDate!,
                   style: const TextStyle(
                     color: Color(0xFF6c757d),
-                    fontSize: 13,
+                    fontSize: 12,
                   ),
                 ),
             ],
@@ -641,8 +677,17 @@ class _DailyLogbookDetailPageState extends State<DailyLogbookDetailPage> {
     final route = _detail?.routeDisplay ?? '-- → --';
     final aircraft = _detail?.tailNumber ?? '--';
     final date = _detail?.formattedDate ?? '--';
-    final departure = _detail?.startTime ?? '--:--';
-    final arrival = _detail?.endTime ?? '--:--';
+    // Read from the live OUT/IN controllers (like Air/Block time below) so
+    // Departure/Arrival update as the user types, without needing to leave
+    // and re-enter the flight to see the saved values reflected.
+    final departure =
+        _outController.text.isNotEmpty
+            ? _outController.text
+            : (_detail?.startTime ?? '--:--');
+    final arrival =
+        _inController.text.isNotEmpty
+            ? _inController.text
+            : (_detail?.endTime ?? '--:--');
 
     return Container(
       width: double.infinity,
@@ -712,14 +757,14 @@ class _DailyLogbookDetailPageState extends State<DailyLogbookDetailPage> {
           _buildSummaryRow('Route', route),
           _buildSummaryRow('Aircraft', aircraft),
           _buildSummaryRow('Date', date),
-          _buildSummaryRow('Departure', departure),
-          _buildSummaryRow('Arrival', arrival),
+          _buildSummaryRow('Departure', departure, valueKey: const Key('departureValue')),
+          _buildSummaryRow('Arrival', arrival, valueKey: const Key('arrivalValue')),
         ],
       ),
     );
   }
 
-  Widget _buildSummaryRow(String label, String value) {
+  Widget _buildSummaryRow(String label, String value, {Key? valueKey}) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 5),
       child: Row(
@@ -735,6 +780,7 @@ class _DailyLogbookDetailPageState extends State<DailyLogbookDetailPage> {
           const Spacer(),
           Text(
             value,
+            key: valueKey,
             style: const TextStyle(
               color: Color(0xFF1a1a2e),
               fontSize: 14,

--- a/lib/features/employee/presentation/bloc/employee_bloc.dart
+++ b/lib/features/employee/presentation/bloc/employee_bloc.dart
@@ -1,5 +1,6 @@
 import 'package:bloc/bloc.dart';
 import 'package:flight_hours_app/core/injector/injector.dart';
+import 'package:flight_hours_app/features/airline_route/domain/usecases/resolve_airline_route_use_case.dart';
 import 'package:flight_hours_app/features/employee/domain/usecases/change_password_use_case.dart';
 import 'package:flight_hours_app/features/employee/domain/usecases/delete_employee_use_case.dart';
 import 'package:flight_hours_app/features/employee/domain/usecases/get_employee_airline_routes_use_case.dart';
@@ -19,6 +20,7 @@ class EmployeeBloc extends Bloc<EmployeeEvent, EmployeeState> {
   final GetEmployeeAirlineUseCase _getEmployeeAirlineUseCase;
   final UpdateEmployeeAirlineUseCase _updateEmployeeAirlineUseCase;
   final GetEmployeeAirlineRoutesUseCase _getEmployeeAirlineRoutesUseCase;
+  final ResolveAirlineRouteUseCase _resolveAirlineRouteUseCase;
 
   EmployeeBloc({
     GetEmployeeUseCase? getEmployeeUseCase,
@@ -28,6 +30,7 @@ class EmployeeBloc extends Bloc<EmployeeEvent, EmployeeState> {
     GetEmployeeAirlineUseCase? getEmployeeAirlineUseCase,
     UpdateEmployeeAirlineUseCase? updateEmployeeAirlineUseCase,
     GetEmployeeAirlineRoutesUseCase? getEmployeeAirlineRoutesUseCase,
+    ResolveAirlineRouteUseCase? resolveAirlineRouteUseCase,
   }) : _getEmployeeUseCase =
            getEmployeeUseCase ?? InjectorApp.resolve<GetEmployeeUseCase>(),
        _updateEmployeeUseCase =
@@ -48,10 +51,14 @@ class EmployeeBloc extends Bloc<EmployeeEvent, EmployeeState> {
        _getEmployeeAirlineRoutesUseCase =
            getEmployeeAirlineRoutesUseCase ??
            InjectorApp.resolve<GetEmployeeAirlineRoutesUseCase>(),
+       _resolveAirlineRouteUseCase =
+           resolveAirlineRouteUseCase ??
+           InjectorApp.resolve<ResolveAirlineRouteUseCase>(),
        super(EmployeeInitial()) {
     on<LoadCurrentEmployee>(_onLoadCurrentEmployee);
     on<LoadEmployeeAirline>(_onLoadEmployeeAirline);
     on<LoadEmployeeAirlineRoutes>(_onLoadEmployeeAirlineRoutes);
+    on<ResolveAirlineRoute>(_onResolveAirlineRoute);
     on<UpdateEmployee>(_onUpdateEmployee);
     on<UpdateEmployeeAirline>(_onUpdateEmployeeAirline);
     on<ChangePassword>(_onChangePassword);
@@ -131,6 +138,29 @@ class EmployeeBloc extends Bloc<EmployeeEvent, EmployeeState> {
           );
         }
       },
+    );
+  }
+
+  Future<void> _onResolveAirlineRoute(
+    ResolveAirlineRoute event,
+    Emitter<EmployeeState> emit,
+  ) async {
+    emit(AirlineRouteResolving());
+
+    final result = await _resolveAirlineRouteUseCase.call(
+      originAirportId: event.originAirportId,
+      destinationAirportId: event.destinationAirportId,
+    );
+    result.fold(
+      (failure) => emit(
+        EmployeeError(
+          message: failure.message,
+          code: failure.code,
+          success: false,
+          statusCode: failure.statusCode,
+        ),
+      ),
+      (airlineRoute) => emit(AirlineRouteResolved(airlineRoute)),
     );
   }
 

--- a/lib/features/employee/presentation/bloc/employee_event.dart
+++ b/lib/features/employee/presentation/bloc/employee_event.dart
@@ -60,5 +60,21 @@ class DeleteEmployee extends EmployeeEvent {}
 /// Uses GET /employees/airline-routes endpoint
 class LoadEmployeeAirlineRoutes extends EmployeeEvent {}
 
+/// Event to resolve (or auto-request as pending) the employee's airline
+/// link for an origin/destination airport pair.
+/// Uses POST /employees/airline-routes/resolve
+class ResolveAirlineRoute extends EmployeeEvent {
+  final String originAirportId;
+  final String destinationAirportId;
+
+  const ResolveAirlineRoute({
+    required this.originAirportId,
+    required this.destinationAirportId,
+  });
+
+  @override
+  List<Object?> get props => [originAirportId, destinationAirportId];
+}
+
 /// Event to reset the state (clear results)
 class ResetEmployeeState extends EmployeeEvent {}

--- a/lib/features/employee/presentation/bloc/employee_state.dart
+++ b/lib/features/employee/presentation/bloc/employee_state.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:flight_hours_app/features/airline_route/domain/entities/airline_route_entity.dart';
 import 'package:flight_hours_app/features/employee/data/models/change_password_model.dart';
 import 'package:flight_hours_app/features/employee/data/models/delete_employee_model.dart';
 import 'package:flight_hours_app/features/employee/data/models/employee_airline_model.dart';
@@ -105,14 +106,35 @@ class EmployeeAirlineRoutesSuccess extends EmployeeState {
 /// Loading state for airline routes
 class EmployeeAirlineRoutesLoading extends EmployeeState {}
 
+/// Loading state while resolving/auto-requesting an airline route link
+class AirlineRouteResolving extends EmployeeState {}
+
+/// Success state for resolving an airline route link — check
+/// `airlineRoute.isPending` to know whether it was just auto-created and is
+/// awaiting admin approval, versus an existing active link.
+class AirlineRouteResolved extends EmployeeState {
+  final AirlineRouteEntity airlineRoute;
+
+  const AirlineRouteResolved(this.airlineRoute);
+
+  @override
+  List<Object?> get props => [airlineRoute];
+}
+
 /// Error state with error details
 class EmployeeError extends EmployeeState {
   final String message;
   final String? code;
   final bool success;
+  final int? statusCode;
 
-  const EmployeeError({required this.message, this.code, this.success = false});
+  const EmployeeError({
+    required this.message,
+    this.code,
+    this.success = false,
+    this.statusCode,
+  });
 
   @override
-  List<Object?> get props => [message, code, success];
+  List<Object?> get props => [message, code, success, statusCode];
 }

--- a/lib/features/logbook/presentation/pages/new_flight_page.dart
+++ b/lib/features/logbook/presentation/pages/new_flight_page.dart
@@ -36,6 +36,12 @@ class _NewFlightPageState extends State<NewFlightPage> {
   bool _isLoadingRoutes = true;
   String? _errorMessage;
 
+  // Set when the origin/destination pair has a physical route but no active
+  // link to the employee's airline yet — the backend auto-creates it as
+  // "pending" and an admin has to approve it before it's usable here.
+  bool _isResolvingRoute = false;
+  AirlineRouteEntity? _pendingRoute;
+
   // Origin/destination airport pickers
   List<AirportEntity> _airports = [];
   bool _isLoadingAirports = true;
@@ -69,6 +75,8 @@ class _NewFlightPageState extends State<NewFlightPage> {
     context.read<AirportBloc>().add(FetchAirports());
     // Fetch logbook ID for the employee
     context.read<FlightBloc>().add(const FetchLogbookId());
+    // Keep the AppBar title (flight number) in sync as the user types
+    _flightController.addListener(() => setState(() {}));
   }
 
   @override
@@ -186,18 +194,60 @@ class _NewFlightPageState extends State<NewFlightPage> {
   /// already-loaded airline routes for this employee. Airline routes are
   /// preconfigured by the admin, so this only picks an existing route —
   /// it never creates one.
+  ///
+  /// Matches by airport ID first — unlike IATA/OACI codes, the ID is always
+  /// present, so this resolves the route regardless of whether the airport
+  /// was searched/selected by its IATA or its OACI code, and even for
+  /// airports that only have an OACI code (no IATA). Falls back to matching
+  /// by IATA code for routes fetched before the airport-ID fields existed.
   void _tryResolveRoute() {
     if (_selectedOrigin == null || _selectedDestination == null) {
-      setState(() => _selectedRoute = null);
+      setState(() {
+        _selectedRoute = null;
+        _pendingRoute = null;
+      });
       return;
     }
-    final match = _airlineRoutes.cast<AirlineRouteEntity?>().firstWhere(
+    final byId = _airlineRoutes.cast<AirlineRouteEntity?>().firstWhere(
       (r) =>
-          r!.originAirportCode == _selectedOrigin!.iataCode &&
-          r.destinationAirportCode == _selectedDestination!.iataCode,
+          r!.originAirportId != null &&
+          r.originAirportId == _selectedOrigin!.id &&
+          r.destinationAirportId == _selectedDestination!.id,
       orElse: () => null,
     );
-    setState(() => _selectedRoute = match);
+    final match =
+        byId ??
+        _airlineRoutes.cast<AirlineRouteEntity?>().firstWhere(
+          (r) =>
+              r!.originAirportCode == _selectedOrigin!.iataCode &&
+              r.destinationAirportCode == _selectedDestination!.iataCode,
+          orElse: () => null,
+        );
+
+    if (match != null) {
+      setState(() {
+        _selectedRoute = match;
+        _pendingRoute = null;
+      });
+      return;
+    }
+
+    // No active link for this airline yet — ask the backend to resolve it.
+    // If a physical route exists for this origin/destination it'll come
+    // back either already usable or freshly auto-created as "pending"; if
+    // no physical route exists at all, this 404s and the UI falls back to
+    // the existing "no route configured" message.
+    setState(() {
+      _selectedRoute = null;
+      _pendingRoute = null;
+      _isResolvingRoute = true;
+    });
+    context.read<EmployeeBloc>().add(
+      ResolveAirlineRoute(
+        originAirportId: _selectedOrigin!.id,
+        destinationAirportId: _selectedDestination!.id,
+      ),
+    );
   }
 
   @override
@@ -229,11 +279,35 @@ class _NewFlightPageState extends State<NewFlightPage> {
                 _isLoadingRoutes = true;
                 _errorMessage = null;
               });
-            } else if (state is EmployeeError) {
+            } else if (state is AirlineRouteResolved) {
               setState(() {
-                _isLoadingRoutes = false;
-                _errorMessage = state.message;
+                _isResolvingRoute = false;
+                if (state.airlineRoute.isActive) {
+                  _selectedRoute = state.airlineRoute;
+                  _pendingRoute = null;
+                } else {
+                  // Pending (just auto-created, or already pending from a
+                  // previous request) — not usable to create a flight yet.
+                  _selectedRoute = null;
+                  _pendingRoute = state.airlineRoute;
+                }
               });
+            } else if (state is EmployeeError) {
+              if (_isResolvingRoute) {
+                // Most commonly a 404 — no physical route configured for
+                // this origin/destination at all. Falls back to the
+                // existing "no route configured" message in that case.
+                setState(() {
+                  _isResolvingRoute = false;
+                  _selectedRoute = null;
+                  _pendingRoute = null;
+                });
+              } else {
+                setState(() {
+                  _isLoadingRoutes = false;
+                  _errorMessage = state.message;
+                });
+              }
             }
           },
         ),
@@ -337,16 +411,42 @@ class _NewFlightPageState extends State<NewFlightPage> {
         icon: const Icon(Icons.arrow_back, color: Color(0xFF1a1a2e)),
         onPressed: () => Navigator.pop(context),
       ),
-      title: Text(
-        _isEditMode ? 'Edit Flight' : 'New Flight',
-        style: const TextStyle(
-          color: Color(0xFF1a1a2e),
-          fontSize: 20,
-          fontWeight: FontWeight.bold,
-        ),
+      title: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            _flightController.text.trim().isNotEmpty
+                ? 'Flight ${_flightController.text.trim()}'
+                : (_isEditMode ? 'Edit Flight' : 'New Flight'),
+            style: const TextStyle(
+              color: Color(0xFF1a1a2e),
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          if (_selectedRoute != null)
+            Text(
+              _routeCodeLabel(_selectedRoute!),
+              style: const TextStyle(color: Color(0xFF6c757d), fontSize: 13),
+            ),
+        ],
       ),
       centerTitle: true,
     );
+  }
+
+  /// Route code for display — prefers IATA (the system's convention) but
+  /// falls back to OACI when an airport in the route has no IATA code.
+  String _routeCodeLabel(AirlineRouteEntity route) {
+    final origin = route.originAirportCode ?? route.originOaciCode ?? '???';
+    final destination =
+        route.destinationAirportCode ?? route.destinationOaciCode ?? '???';
+    return '$origin → $destination';
+  }
+
+  /// Airport code for display — prefers IATA, falls back to OACI.
+  String _airportCodeLabel(AirportEntity airport) {
+    return airport.iataCode ?? airport.oaciCode ?? '???';
   }
 
   Widget _buildInputField({
@@ -497,6 +597,7 @@ class _NewFlightPageState extends State<NewFlightPage> {
                     setState(() {
                       _selectedOrigin = null;
                       _selectedRoute = null;
+                      _pendingRoute = null;
                     });
                   },
                 ),
@@ -522,6 +623,7 @@ class _NewFlightPageState extends State<NewFlightPage> {
                     setState(() {
                       _selectedDestination = null;
                       _selectedRoute = null;
+                      _pendingRoute = null;
                     });
                   },
                 ),
@@ -722,14 +824,15 @@ class _NewFlightPageState extends State<NewFlightPage> {
   }
 
   /// "City, IATA - Country" — falls back to the airport name for whichever
-  /// piece isn't populated yet (e.g. before the city/country migration ran).
+  /// piece isn't populated yet (e.g. before the city/country migration ran),
+  /// and to the OACI code when the airport has no IATA code at all.
   String _airportLocationLabel(AirportEntity airport) {
     final city = (airport.city ?? '').isNotEmpty ? airport.city! : airport.name;
-    final iata = airport.iataCode ?? '---';
+    final code = _airportCodeLabel(airport);
     if ((airport.country ?? '').isNotEmpty) {
-      return '$city, $iata - ${airport.country}';
+      return '$city, $code - ${airport.country}';
     }
-    return '$city, $iata';
+    return '$city, $code';
   }
 
   /// Airport name plus OACI code when available, e.g. "El Dorado · OACI SKBO".
@@ -741,7 +844,7 @@ class _NewFlightPageState extends State<NewFlightPage> {
   }
 
   Widget _buildRouteResolutionArea() {
-    if (_isLoadingRoutes || _isLoadingAirports) {
+    if (_isLoadingRoutes || _isLoadingAirports || _isResolvingRoute) {
       return const Padding(
         padding: EdgeInsets.symmetric(vertical: 12),
         child: Center(
@@ -789,6 +892,7 @@ class _NewFlightPageState extends State<NewFlightPage> {
               onPressed: () {
                 setState(() {
                   _selectedRoute = null;
+                  _pendingRoute = null;
                   _selectedOrigin = null;
                   _selectedDestination = null;
                 });
@@ -801,6 +905,34 @@ class _NewFlightPageState extends State<NewFlightPage> {
             ),
           ),
         ],
+      );
+    }
+
+    if (_pendingRoute != null) {
+      return Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: const Color(0xFFf5a623).withValues(alpha: 0.1),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Icon(
+              Icons.hourglass_top,
+              color: Color(0xFFf5a623),
+              size: 20,
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                'Ruta ${_routeCodeLabel(_pendingRoute!)} enviada para aprobación del administrador. Podrás usarla una vez sea aprobada.',
+                style: const TextStyle(color: Color(0xFFb8770f), fontSize: 13),
+              ),
+            ),
+          ],
+        ),
       );
     }
 
@@ -818,7 +950,7 @@ class _NewFlightPageState extends State<NewFlightPage> {
             const SizedBox(width: 10),
             Expanded(
               child: Text(
-                'No hay ruta configurada para ${_selectedOrigin!.iataCode ?? '???'} → ${_selectedDestination!.iataCode ?? '???'}',
+                'No hay ruta configurada para ${_airportCodeLabel(_selectedOrigin!)} → ${_airportCodeLabel(_selectedDestination!)}',
                 style: const TextStyle(color: Color(0xFFe17055), fontSize: 13),
               ),
             ),
@@ -849,7 +981,7 @@ class _NewFlightPageState extends State<NewFlightPage> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  '${_selectedRoute!.originAirportCode ?? '???'} → ${_selectedRoute!.destinationAirportCode ?? '???'}',
+                  _routeCodeLabel(_selectedRoute!),
                   style: const TextStyle(
                     color: Colors.white,
                     fontSize: 16,

--- a/test/features/airline_route/domain/entities/airline_route_entity_test.dart
+++ b/test/features/airline_route/domain/entities/airline_route_entity_test.dart
@@ -184,12 +184,16 @@ void main() {
         routeName: 'Name',
         airlineName: 'Airline',
         airlineCode: 'AV',
+        originAirportId: 'origin-id',
         originAirportCode: 'BOG',
+        originOaciCode: 'SKBO',
+        destinationAirportId: 'dest-id',
         destinationAirportCode: 'MDE',
+        destinationOaciCode: 'SKRG',
         status: 'active',
       );
 
-      expect(entity.props.length, equals(10));
+      expect(entity.props.length, equals(14));
     });
   });
 }

--- a/test/features/daily_logbook_detail/presentation/pages/daily_logbook_detail_page_test.dart
+++ b/test/features/daily_logbook_detail/presentation/pages/daily_logbook_detail_page_test.dart
@@ -1,0 +1,120 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flight_hours_app/features/logbook/domain/entities/logbook_detail_entity.dart';
+import 'package:flight_hours_app/features/logbook/presentation/bloc/logbook_bloc.dart';
+import 'package:flight_hours_app/features/logbook/presentation/bloc/logbook_event.dart';
+import 'package:flight_hours_app/features/logbook/presentation/bloc/logbook_state.dart';
+import 'package:flight_hours_app/features/daily_logbook_detail/presentation/pages/daily_logbook_detail_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockLogbookBloc extends MockBloc<LogbookEvent, LogbookState>
+    implements LogbookBloc {}
+
+class FakeLogbookEvent extends Fake implements LogbookEvent {}
+
+void main() {
+  late MockLogbookBloc mockBloc;
+
+  setUpAll(() {
+    registerFallbackValue(FakeLogbookEvent());
+  });
+
+  setUp(() {
+    mockBloc = MockLogbookBloc();
+    when(() => mockBloc.state).thenReturn(const LogbookInitial());
+  });
+
+  final existingDetail = LogbookDetailEntity(
+    id: '1',
+    uuid: 'uuid-1',
+    dailyLogbookId: 'logbook-1',
+    flightNumber: '4043',
+    flightRealDate: DateTime(2026, 7, 22),
+    originIataCode: 'MDE',
+    destinationIataCode: 'BOG',
+    routeCode: 'MDE-BOG',
+    tailNumber: 'CC-BAQ',
+    outTime: '10:00:00',
+    takeoffTime: '10:15:00',
+    landingTime: '11:15:00',
+    inTime: '11:30:00',
+    pilotRole: 'PF',
+  );
+
+  Widget createWidgetUnderTest() {
+    // DailyLogbookDetailPage reads its data from
+    // ModalRoute.of(context)?.settings.arguments, so it must be pushed as a
+    // route carrying those arguments rather than dropped in via `home:`.
+    return MaterialApp(
+      home: Navigator(
+        onGenerateRoute:
+            (settings) => MaterialPageRoute(
+              settings: RouteSettings(
+                arguments: {'detail': existingDetail},
+              ),
+              builder:
+                  (_) => BlocProvider<LogbookBloc>.value(
+                    value: mockBloc,
+                    child: const DailyLogbookDetailPage(),
+                  ),
+            ),
+      ),
+    );
+  }
+
+  testWidgets(
+    'Departure/Arrival update live when OUT/IN are edited, without leaving the page',
+    (tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pumpAndSettle();
+
+      // Simulate reopening an already-saved flight — Departure/Arrival start
+      // from the persisted OUT/IN times (10:00 / 11:30).
+      Text valueOf(Key key) => tester.widget<Text>(find.byKey(key));
+      expect(valueOf(const Key('departureValue')).data, '10:00');
+      expect(valueOf(const Key('arrivalValue')).data, '11:30');
+
+      // Edit OUT and IN like a pilot correcting the saved times.
+      await tester.enterText(find.widgetWithText(TextField, 'HH:MM').at(0), '0930');
+      await tester.pump();
+      await tester.enterText(find.widgetWithText(TextField, 'HH:MM').at(3), '1200');
+      await tester.pump();
+
+      // Departure/Arrival must reflect the new values immediately — no
+      // navigation, no re-fetch — this is the exact bug being fixed.
+      expect(valueOf(const Key('departureValue')).data, '09:30');
+      expect(valueOf(const Key('arrivalValue')).data, '12:00');
+    },
+  );
+
+  testWidgets(
+    'AppBar title shows flight number + route, and the date from the flight itself '
+    '(not from a `logbook` argument, which is absent right after creating a flight)',
+    (tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pumpAndSettle();
+
+      final appBarTitle = find.descendant(
+        of: find.byType(AppBar),
+        matching: find.byType(Column),
+      );
+      expect(
+        find.descendant(of: appBarTitle, matching: find.text('Flight 4043')),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(of: appBarTitle, matching: find.text('MDE-BOG')),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: appBarTitle,
+          matching: find.text('July 22, 2026'),
+        ),
+        findsOneWidget,
+      );
+    },
+  );
+}

--- a/test/features/employee/presentation/bloc/employee_bloc_test.dart
+++ b/test/features/employee/presentation/bloc/employee_bloc_test.dart
@@ -3,6 +3,7 @@ import 'package:dartz/dartz.dart';
 import 'package:flight_hours_app/core/error/failure.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:flight_hours_app/features/airline_route/domain/usecases/resolve_airline_route_use_case.dart';
 import 'package:flight_hours_app/features/employee/data/models/change_password_model.dart';
 import 'package:flight_hours_app/features/employee/data/models/delete_employee_model.dart';
 import 'package:flight_hours_app/features/employee/data/models/employee_airline_model.dart';
@@ -36,6 +37,9 @@ class MockUpdateEmployeeAirlineUseCase extends Mock
 
 class MockGetEmployeeAirlineRoutesUseCase extends Mock
     implements GetEmployeeAirlineRoutesUseCase {}
+
+class MockResolveAirlineRouteUseCase extends Mock
+    implements ResolveAirlineRouteUseCase {}
 
 void main() {
   group('EmployeeEvent', () {
@@ -179,7 +183,7 @@ void main() {
           success: false,
         );
 
-        expect(state.props.length, equals(3));
+        expect(state.props.length, equals(4));
         expect(state.props, contains('Error'));
         expect(state.props, contains('CODE'));
       });
@@ -202,6 +206,7 @@ void main() {
     late MockGetEmployeeAirlineUseCase mockGetAirlineUseCase;
     late MockUpdateEmployeeAirlineUseCase mockUpdateAirlineUseCase;
     late MockGetEmployeeAirlineRoutesUseCase mockGetRoutesUseCase;
+    late MockResolveAirlineRouteUseCase mockResolveAirlineRouteUseCase;
 
     setUpAll(() {
       registerFallbackValue(
@@ -233,6 +238,7 @@ void main() {
       mockGetAirlineUseCase = MockGetEmployeeAirlineUseCase();
       mockUpdateAirlineUseCase = MockUpdateEmployeeAirlineUseCase();
       mockGetRoutesUseCase = MockGetEmployeeAirlineRoutesUseCase();
+      mockResolveAirlineRouteUseCase = MockResolveAirlineRouteUseCase();
     });
 
     EmployeeBloc buildBloc() {
@@ -244,6 +250,7 @@ void main() {
         getEmployeeAirlineUseCase: mockGetAirlineUseCase,
         updateEmployeeAirlineUseCase: mockUpdateAirlineUseCase,
         getEmployeeAirlineRoutesUseCase: mockGetRoutesUseCase,
+        resolveAirlineRouteUseCase: mockResolveAirlineRouteUseCase,
       );
     }
 

--- a/test/features/employee/presentation/bloc/employee_state_test.dart
+++ b/test/features/employee/presentation/bloc/employee_state_test.dart
@@ -167,14 +167,15 @@ void main() {
         expect(state.code, isNull);
       });
 
-      test('props should contain message, code and success', () {
+      test('props should contain message, code, success and statusCode', () {
         const state = EmployeeError(
           message: 'msg',
           code: 'code',
           success: true,
+          statusCode: 404,
         );
 
-        expect(state.props.length, equals(3));
+        expect(state.props.length, equals(4));
       });
     });
   });

--- a/test/features/logbook/presentation/pages/new_flight_page_test.dart
+++ b/test/features/logbook/presentation/pages/new_flight_page_test.dart
@@ -1,0 +1,334 @@
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flight_hours_app/features/airline_route/domain/entities/airline_route_entity.dart';
+import 'package:flight_hours_app/features/airport/domain/entities/airport_entity.dart';
+import 'package:flight_hours_app/features/airport/presentation/bloc/airport_bloc.dart';
+import 'package:flight_hours_app/features/airport/presentation/bloc/airport_event.dart';
+import 'package:flight_hours_app/features/airport/presentation/bloc/airport_state.dart';
+import 'package:flight_hours_app/features/employee/data/models/employee_airline_routes_model.dart';
+import 'package:flight_hours_app/features/employee/presentation/bloc/employee_bloc.dart';
+import 'package:flight_hours_app/features/employee/presentation/bloc/employee_event.dart';
+import 'package:flight_hours_app/features/employee/presentation/bloc/employee_state.dart';
+import 'package:flight_hours_app/features/flight/presentation/bloc/flight_bloc.dart';
+import 'package:flight_hours_app/features/flight/presentation/bloc/flight_event.dart';
+import 'package:flight_hours_app/features/flight/presentation/bloc/flight_state.dart';
+import 'package:flight_hours_app/features/logbook/presentation/pages/new_flight_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockEmployeeBloc extends MockBloc<EmployeeEvent, EmployeeState>
+    implements EmployeeBloc {}
+
+class MockAirportBloc extends MockBloc<AirportEvent, AirportState>
+    implements AirportBloc {}
+
+class MockFlightBloc extends MockBloc<FlightEvent, FlightState>
+    implements FlightBloc {}
+
+class FakeEmployeeEvent extends Fake implements EmployeeEvent {}
+
+class FakeAirportEvent extends Fake implements AirportEvent {}
+
+class FakeFlightEvent extends Fake implements FlightEvent {}
+
+void main() {
+  late MockEmployeeBloc employeeBloc;
+  late MockAirportBloc airportBloc;
+  late MockFlightBloc flightBloc;
+
+  setUpAll(() {
+    registerFallbackValue(FakeEmployeeEvent());
+    registerFallbackValue(FakeAirportEvent());
+    registerFallbackValue(FakeFlightEvent());
+  });
+
+  setUp(() {
+    employeeBloc = MockEmployeeBloc();
+    airportBloc = MockAirportBloc();
+    flightBloc = MockFlightBloc();
+    when(() => employeeBloc.state).thenReturn(EmployeeInitial());
+    when(() => airportBloc.state).thenReturn(AirportInitial());
+    when(() => flightBloc.state).thenReturn(const FlightInitial());
+  });
+
+  Widget createWidgetUnderTest({Map<String, dynamic>? arguments}) {
+    return MaterialApp(
+      home: MultiBlocProvider(
+        providers: [
+          BlocProvider<EmployeeBloc>.value(value: employeeBloc),
+          BlocProvider<AirportBloc>.value(value: airportBloc),
+          BlocProvider<FlightBloc>.value(value: flightBloc),
+        ],
+        child: Navigator(
+          onGenerateRoute:
+              (settings) => MaterialPageRoute(
+                settings: RouteSettings(arguments: arguments),
+                builder: (_) => const NewFlightPage(),
+              ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('shows "New Flight" with no route subtitle before typing anything', (
+    tester,
+  ) async {
+    await tester.pumpWidget(createWidgetUnderTest());
+    await tester.pump();
+
+    expect(find.text('New Flight'), findsOneWidget);
+    expect(find.textContaining('→'), findsNothing);
+  });
+
+  testWidgets('updates the AppBar title with the flight number as the user types', (
+    tester,
+  ) async {
+    await tester.pumpWidget(createWidgetUnderTest());
+    await tester.pump();
+
+    await tester.enterText(find.byType(TextFormField).first, '4043');
+    await tester.pump();
+
+    expect(find.text('Flight 4043'), findsOneWidget);
+    expect(find.text('New Flight'), findsNothing);
+  });
+
+  testWidgets(
+    'resolves the route by airport ID when the origin airport has only an '
+    'OACI code (no IATA), and falls back to OACI for display',
+    (tester) async {
+      // Olaya Herrera only has an OACI code — this is the real-world case
+      // that used to be unresolvable when matching was done by IATA code.
+      final origin = const AirportEntity(
+        id: 'ap-1',
+        name: 'Olaya Herrera',
+        oaciCode: 'SKRG',
+      );
+      final destination = const AirportEntity(
+        id: 'ap-2',
+        name: 'El Dorado',
+        iataCode: 'BOG',
+        oaciCode: 'SKBO',
+      );
+      final route = const AirlineRouteEntity(
+        id: 'r1',
+        routeId: 'route-1',
+        airlineId: 'airline-1',
+        originAirportId: 'ap-1',
+        originOaciCode: 'SKRG',
+        destinationAirportId: 'ap-2',
+        destinationAirportCode: 'BOG',
+        airlineName: 'Test Air',
+      );
+
+      whenListen(
+        airportBloc,
+        Stream.value(AirportSuccess([origin, destination])),
+        initialState: AirportInitial(),
+      );
+      whenListen(
+        employeeBloc,
+        Stream.value(
+          EmployeeAirlineRoutesSuccess(
+            EmployeeAirlineRoutesResponseModel(
+              success: true,
+              code: 'OK',
+              message: 'ok',
+              data: [route],
+            ),
+          ),
+        ),
+        initialState: EmployeeInitial(),
+      );
+
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pump();
+
+      // Search and select the origin by its OACI code.
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Ingrese origen'),
+        'SKRG',
+      );
+      await tester.pump();
+
+      // The search result's primary label falls back to the OACI code
+      // instead of showing a blank/placeholder IATA slot.
+      expect(find.text('Olaya Herrera, SKRG'), findsOneWidget);
+
+      await tester.tap(find.textContaining('Olaya Herrera').first);
+      await tester.pump();
+
+      // Search and select the destination by its IATA code.
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Ingrese destino'),
+        'BOG',
+      );
+      await tester.pump();
+      await tester.tap(find.textContaining('El Dorado').first);
+      await tester.pump();
+
+      // The route resolved (by airport ID) and the card shows the OACI
+      // fallback for the origin since it has no IATA code.
+      expect(find.text('SKRG → BOG'), findsWidgets);
+      expect(find.textContaining('No hay ruta configurada'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'auto-requests a pending airline_route link when the origin/destination '
+    'pair has no active link for the employee\'s airline yet',
+    (tester) async {
+      final origin = const AirportEntity(id: 'ap-1', name: 'Rionegro', iataCode: 'MDE');
+      final destination = const AirportEntity(
+        id: 'ap-2',
+        name: 'El Dorado',
+        iataCode: 'BOG',
+      );
+
+      final employeeStates = StreamController<EmployeeState>.broadcast();
+      addTearDown(employeeStates.close);
+      whenListen(
+        employeeBloc,
+        employeeStates.stream,
+        initialState: EmployeeInitial(),
+      );
+      whenListen(
+        airportBloc,
+        Stream.value(AirportSuccess([origin, destination])),
+        initialState: AirportInitial(),
+      );
+
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pump();
+
+      // No local match: the employee's airline has zero active routes.
+      // Pushed only after the widget is mounted — a broadcast stream drops
+      // events emitted before anything subscribes.
+      employeeStates.add(
+        EmployeeAirlineRoutesSuccess(
+          EmployeeAirlineRoutesResponseModel(
+            success: true,
+            code: 'OK',
+            message: 'ok',
+            data: const [],
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Ingrese origen'),
+        'MDE',
+      );
+      await tester.pump();
+      await tester.tap(find.textContaining('Rionegro').first);
+      await tester.pump();
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Ingrese destino'),
+        'BOG',
+      );
+      await tester.pump();
+      await tester.tap(find.textContaining('El Dorado').first);
+      await tester.pump();
+
+      // Dispatched the resolve request with the raw (non-obfuscated in this
+      // test) airport IDs from the selected AirportEntity objects.
+      final captured =
+          verify(
+                () => employeeBloc.add(captureAny(that: isA<ResolveAirlineRoute>())),
+              ).captured.single
+              as ResolveAirlineRoute;
+      expect(captured.originAirportId, 'ap-1');
+      expect(captured.destinationAirportId, 'ap-2');
+
+      // Backend auto-created the link as pending — surface that instead of
+      // silently blocking or showing the "no route configured" error.
+      employeeStates.add(
+        const AirlineRouteResolved(
+          AirlineRouteEntity(
+            id: 'ar-new',
+            routeId: 'route-1',
+            airlineId: 'airline-1',
+            status: 'pending',
+            originAirportCode: 'MDE',
+            destinationAirportCode: 'BOG',
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.textContaining('enviada para aprobación'), findsOneWidget);
+      expect(find.textContaining('No hay ruta configurada'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'falls back to the "no route configured" message when resolve 404s '
+    '(no physical route exists for that pair at all)',
+    (tester) async {
+      final origin = const AirportEntity(id: 'ap-1', name: 'Rionegro', iataCode: 'MDE');
+      final destination = const AirportEntity(
+        id: 'ap-3',
+        name: 'Somewhere Else',
+        iataCode: 'XYZ',
+      );
+
+      final employeeStates = StreamController<EmployeeState>.broadcast();
+      addTearDown(employeeStates.close);
+      whenListen(
+        employeeBloc,
+        employeeStates.stream,
+        initialState: EmployeeInitial(),
+      );
+      whenListen(
+        airportBloc,
+        Stream.value(AirportSuccess([origin, destination])),
+        initialState: AirportInitial(),
+      );
+
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pump();
+
+      employeeStates.add(
+        EmployeeAirlineRoutesSuccess(
+          EmployeeAirlineRoutesResponseModel(
+            success: true,
+            code: 'OK',
+            message: 'ok',
+            data: const [],
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Ingrese origen'),
+        'MDE',
+      );
+      await tester.pump();
+      await tester.tap(find.textContaining('Rionegro').first);
+      await tester.pump();
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Ingrese destino'),
+        'XYZ',
+      );
+      await tester.pump();
+      await tester.tap(find.textContaining('Somewhere Else').first);
+      await tester.pump();
+
+      employeeStates.add(
+        const EmployeeError(message: 'Route not found', statusCode: 404),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.textContaining('No hay ruta configurada'), findsOneWidget);
+      expect(find.textContaining('enviada para aprobación'), findsNothing);
+    },
+  );
+}


### PR DESCRIPTION
Pulido de New Flight y Daily Logbook Detail (títulos, horas en vivo) + resolución automática de rutas pendientes por aerolínea
 (1) Daily Logbook Detail ahora calcula Departure/Arrival en vivo mientras se editan OUT/IN, sin salir y volver a entrar al vuelo; (2) el título de New Flight muestra el número de vuelo y el código de ruta (IATA, con fallback a OACI) a medida que se completan; (3) el título de Daily Logbook Detail muestra número de vuelo, origen/destino y fecha, tomando la fecha del propio vuelo en vez de depender de un argumento `logbook` que no siempre llega; (4) la búsqueda de aeropuertos en New Flight ya resuelve la ruta por ID de aeropuerto en vez de por código IATA, así que buscar por OACI (o un aeropuerto sin IATA) también encuentra la ruta correcta.

Además, cuando el empleado elige un origen/destino con ruta física configurada pero sin vínculo activo a su aerolínea, la app ahora solicita automáticamente ese vínculo al backend (status "pending") y muestra un aviso de "pendiente de aprobación" en vez de bloquear sin explicación — el admin solo tiene que activarlo desde Airline Routes, sin crearlo a mano.origen/destino y fecha, tomando la fecha del propio vuelo en vez de depender de un argumento `logbook` que no siempre llega; (4) la búsqueda de aeropuertos en New Flight ya resuelve la ruta por ID de aeropuerto en vez de por código IATA, así que buscar por OACI (o un aeropuerto sin IATA) también encuentra la ruta correcta.

Además, cuando el empleado elige un origen/destino con ruta física configurada pero sin vínculo activo a su aerolínea, la app ahora solicita automáticamente ese vínculo al backend (status "pending") y muestra un aviso de "pendiente de aprobación" en vez de bloquear sin explicación — el admin solo tiene que activarlo desde Airline Routes, sin crearlo a mano.