### PR TITLE
Default Crew Role in New Logbook Entry to last-used value

### DIFF
--- a/lib/features/logbook/presentation/pages/logbook_page.dart
+++ b/lib/features/logbook/presentation/pages/logbook_page.dart
@@ -1,4 +1,7 @@
 import 'package:flight_hours_app/core/responsive/responsive_padding.dart';
+import 'package:flight_hours_app/features/flight_summary/presentation/bloc/flight_summary_bloc.dart';
+import 'package:flight_hours_app/features/flight_summary/presentation/bloc/flight_summary_event.dart';
+import 'package:flight_hours_app/features/flight_summary/presentation/bloc/flight_summary_state.dart';
 import 'package:flight_hours_app/features/logbook/domain/entities/daily_logbook_entity.dart';
 import 'package:flight_hours_app/features/logbook/domain/entities/logbook_detail_entity.dart';
 import 'package:flight_hours_app/features/logbook/presentation/bloc/logbook_bloc.dart';
@@ -1394,6 +1397,20 @@ class _LogbookPageState extends State<LogbookPage> {
     );
   }
 
+  /// Returns the crew_role of the most recently saved flight, skipping any
+  /// with no crew_role set. Recent flights already come sorted newest-first
+  /// from the backend (see GET /employees/recent-flights).
+  String? _lastCrewRoleFrom(FlightSummaryState state) {
+    if (state is! RecentFlightsSuccess) return null;
+    for (final flight in state.flights) {
+      if (flight.crewRole != null &&
+          _newLogbookCrewRoles.contains(flight.crewRole)) {
+        return flight.crewRole;
+      }
+    }
+    return null;
+  }
+
   /// Show the create logbook form dialog
   void _showLogbookFormDialog() {
     final dateController = TextEditingController();
@@ -1403,7 +1420,17 @@ class _LogbookPageState extends State<LogbookPage> {
     TailNumberEntity? selectedTailNumber;
     bool isSearchingTailNumber = false;
     bool tailNumberNotFound = false;
-    String? selectedCrewRole;
+
+    // Default Crew Role to whatever the pilot last flew as — pulled from the
+    // recent-flights cache (already loaded at login) so new logbooks don't
+    // start with the field empty every time. Still fully overridable below.
+    final flightSummaryState = context.read<FlightSummaryBloc>().state;
+    String? selectedCrewRole = _lastCrewRoleFrom(flightSummaryState);
+    if (flightSummaryState is! RecentFlightsSuccess) {
+      // Not loaded yet (e.g. bloc was reset) — fetch it and apply the
+      // default once it arrives, via the BlocListener below.
+      context.read<FlightSummaryBloc>().add(LoadRecentFlights());
+    }
 
     // Auto-increment: find max book_page from existing logbooks
     final state = context.read<LogbookBloc>().state;
@@ -1426,23 +1453,41 @@ class _LogbookPageState extends State<LogbookPage> {
       builder: (dialogContext) {
         return StatefulBuilder(
           builder: (context, setDialogState) {
-            return BlocListener<TailNumberBloc, TailNumberState>(
-              listener: (context, tailNumberState) {
-                if (tailNumberState is TailNumberSuccess) {
-                  setDialogState(() {
-                    selectedTailNumber = tailNumberState.tailNumber;
-                    isSearchingTailNumber = false;
-                    tailNumberNotFound = false;
-                  });
-                } else if (tailNumberState is TailNumberError) {
-                  setDialogState(() {
-                    isSearchingTailNumber = false;
-                    tailNumberNotFound = true;
-                  });
-                } else if (tailNumberState is TailNumberLoading) {
-                  setDialogState(() => isSearchingTailNumber = true);
-                }
-              },
+            return MultiBlocListener(
+              listeners: [
+                BlocListener<TailNumberBloc, TailNumberState>(
+                  listener: (context, tailNumberState) {
+                    if (tailNumberState is TailNumberSuccess) {
+                      setDialogState(() {
+                        selectedTailNumber = tailNumberState.tailNumber;
+                        isSearchingTailNumber = false;
+                        tailNumberNotFound = false;
+                      });
+                    } else if (tailNumberState is TailNumberError) {
+                      setDialogState(() {
+                        isSearchingTailNumber = false;
+                        tailNumberNotFound = true;
+                      });
+                    } else if (tailNumberState is TailNumberLoading) {
+                      setDialogState(() => isSearchingTailNumber = true);
+                    }
+                  },
+                ),
+                BlocListener<FlightSummaryBloc, FlightSummaryState>(
+                  listener: (context, flightSummaryState) {
+                    // Applies the last-used-crew-role default if it wasn't
+                    // ready yet when the dialog opened. Only fills the field
+                    // in — never overwrites a role the pilot already picked.
+                    if (selectedCrewRole == null &&
+                        flightSummaryState is RecentFlightsSuccess) {
+                      final lastRole = _lastCrewRoleFrom(flightSummaryState);
+                      if (lastRole != null) {
+                        setDialogState(() => selectedCrewRole = lastRole);
+                      }
+                    }
+                  },
+                ),
+              ],
               child: AlertDialog(
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(20),


### PR DESCRIPTION
 El campo Crew Role en el diálogo "New Logbook Entry" arrancaba vacío siempre, obligando a re-seleccionar el mismo rol (captain, first officer, instructor, line check captain o safety pilot) en cada bitácora nueva.
 Ahora se precarga por default con el crew_role del vuelo guardado más reciente (tomado del cache de recent-flights que ya se carga al hacer login), manteniéndose totalmente editable por bitácora — mismo patrón UX que el default de crew role por bitácora ya existente.
Contempla el caso en que el cache de recent-flights todavía no esté listo cuando se abre el diálogo: dispara LoadRecentFlights() y aplica el default apenas llega, sin pisar nunca un rol que el piloto ya haya elegido manualmente. Defensivo: solo aplica un valor recordado si coincide con una de las 5 opciones de rol conocidas, para evitar un crash del DropdownButton ante un dato inesperado del backend.