### PR TITLE
Fix Crew Role default: order by book_page, not log_date

### DIFF
--- a/lib/features/logbook/presentation/pages/logbook_page.dart
+++ b/lib/features/logbook/presentation/pages/logbook_page.dart
@@ -1395,19 +1395,26 @@ class _LogbookPageState extends State<LogbookPage> {
   }
 
   /// Returns the crew_role of the most recently created bitácora, skipping
-  /// any with no crew_role set. `daily_logbook` rows come sorted newest-first
-  /// from the backend (`ORDER BY log_date DESC`), so the first match is the
-  /// role to default to — this reads directly off the bitácora header field
-  /// the pilot picks on this very form, so it updates the instant a new
-  /// bitácora is created, even before any flight is logged under it.
+  /// any with no crew_role set. The backend sorts `daily_logbook` rows by
+  /// `log_date DESC`, but log_date is the calendar date the pilot picked for
+  /// that book page — not a creation timestamp — so a bitácora logged out of
+  /// date order (e.g. catching up on an earlier flight) can sort ahead of
+  /// one created afterward. `book_page` increases monotonically as bitácoras
+  /// are created (it's the same signal the auto-increment above relies on),
+  /// so it's the reliable "most recent" indicator here, not list order.
   String? _lastCrewRoleFrom(List<DailyLogbookEntity> logbooks) {
+    DailyLogbookEntity? latest;
     for (final logbook in logbooks) {
-      if (logbook.crewRole != null &&
-          _newLogbookCrewRoles.contains(logbook.crewRole)) {
-        return logbook.crewRole;
+      if (logbook.crewRole == null ||
+          !_newLogbookCrewRoles.contains(logbook.crewRole)) {
+        continue;
+      }
+      if (latest == null ||
+          (logbook.bookPage ?? -1) > (latest.bookPage ?? -1)) {
+        latest = logbook;
       }
     }
-    return null;
+    return latest?.crewRole;
   }
 
   /// Show the create logbook form dialog


### PR DESCRIPTION
- Sigue a los PR #61 y #62 (ya mergeados). El default de Crew Role en "New Logbook Entry" seguía mostrando un rol viejo en un caso concreto: crear una bitácora con "safety pilot", guardarle vuelos, y al crear la siguiente bitácora seguía apareciendo "captain".
- Causa raíz: el default tomaba el primer elemento de la lista de bitácoras devuelta por el backend, que viene ordenada por log_date DESC (la fecha del vuelo que elige el piloto). Esa fecha no es un timestamp de creación — si una bitácora se carga fuera de orden cronológico (p. ej. poniendo al día un vuelo de una fecha anterior), puede aparecer antes que una creada después con una fecha más reciente, y el default terminaba apuntando al rol equivocado.
- Fix: usar book_page como criterio de "más reciente" en vez del orden de la lista — crece de forma secuencial en cada bitácora nueva (es la misma señal que ya usa el auto-incremento del campo book_page en este mismo formulario), así que es un indicador confiable de orden de creación, a diferencia de log_date.
- No requiere cambios de backend: book_page y crew_role ya venían en cada fila del endpoint existente.