### PR TITLE
Fix Crew Role default: use created_at, not book_page/log_date

### DIFF
--- a/lib/features/logbook/data/models/daily_logbook_model.dart
+++ b/lib/features/logbook/data/models/daily_logbook_model.dart
@@ -13,6 +13,7 @@ class DailyLogbookModel extends DailyLogbookEntity {
     super.tailNumberId,
     super.tailNumber,
     super.crewRole,
+    super.createdAt,
   });
 
   /// Factory constructor to create DailyLogbookModel from JSON
@@ -37,6 +38,7 @@ class DailyLogbookModel extends DailyLogbookEntity {
       tailNumberId: json['tail_number_id']?.toString(),
       tailNumber: json['tail_number']?.toString(),
       crewRole: json['crew_role']?.toString(),
+      createdAt: _parseDate(json['created_at']),
     );
   }
 

--- a/lib/features/logbook/domain/entities/daily_logbook_entity.dart
+++ b/lib/features/logbook/domain/entities/daily_logbook_entity.dart
@@ -14,6 +14,8 @@ class DailyLogbookEntity extends Equatable {
   final String? tailNumber; // Denormalized plate, for display
   final String?
   crewRole; // Default crew role for every flight in this book page (editable per flight)
+  final DateTime?
+  createdAt; // DB-assigned creation timestamp, not editable by the pilot
 
   const DailyLogbookEntity({
     required this.id,
@@ -25,6 +27,7 @@ class DailyLogbookEntity extends Equatable {
     this.tailNumberId,
     this.tailNumber,
     this.crewRole,
+    this.createdAt,
   });
 
   /// Returns a display-friendly logbook ID
@@ -78,5 +81,6 @@ class DailyLogbookEntity extends Equatable {
     tailNumberId,
     tailNumber,
     crewRole,
+    createdAt,
   ];
 }

--- a/lib/features/logbook/presentation/pages/logbook_page.dart
+++ b/lib/features/logbook/presentation/pages/logbook_page.dart
@@ -1395,13 +1395,13 @@ class _LogbookPageState extends State<LogbookPage> {
   }
 
   /// Returns the crew_role of the most recently created bitácora, skipping
-  /// any with no crew_role set. The backend sorts `daily_logbook` rows by
-  /// `log_date DESC`, but log_date is the calendar date the pilot picked for
-  /// that book page — not a creation timestamp — so a bitácora logged out of
-  /// date order (e.g. catching up on an earlier flight) can sort ahead of
-  /// one created afterward. `book_page` increases monotonically as bitácoras
-  /// are created (it's the same signal the auto-increment above relies on),
-  /// so it's the reliable "most recent" indicator here, not list order.
+  /// any with no crew_role set. Neither `log_date` (a calendar date the pilot
+  /// picks freely, including past dates when backfilling a flight) nor
+  /// `book_page` (a physical logbook page code, not a sequential app
+  /// counter) reliably reflects real creation order — both are editable by
+  /// the pilot and can end up "out of order" relative to when a bitácora was
+  /// actually saved. `created_at` is a DB-assigned timestamp the pilot never
+  /// touches, so it's the only field that can't be thrown off this way.
   String? _lastCrewRoleFrom(List<DailyLogbookEntity> logbooks) {
     DailyLogbookEntity? latest;
     for (final logbook in logbooks) {
@@ -1410,7 +1410,9 @@ class _LogbookPageState extends State<LogbookPage> {
         continue;
       }
       if (latest == null ||
-          (logbook.bookPage ?? -1) > (latest.bookPage ?? -1)) {
+          (logbook.createdAt ?? DateTime(0)).isAfter(
+            latest.createdAt ?? DateTime(0),
+          )) {
         latest = logbook;
       }
     }

--- a/test/features/logbook/domain/entities/daily_logbook_entity_test.dart
+++ b/test/features/logbook/domain/entities/daily_logbook_entity_test.dart
@@ -136,7 +136,7 @@ void main() {
         status: true,
       );
 
-      expect(entity.props.length, equals(9));
+      expect(entity.props.length, equals(10));
     });
   });
 }


### PR DESCRIPTION
- Sigue a los PR #61/#62/#63. Pruebas reales mostraron que book_page también fallaba como proxy de "creada más recientemente" (es un código de página física, no secuencial).
- Ahora usa daily_logbook.created_at (companion en api-flighthours, PR pendiente) — timestamp que la DB asigna sola, inmune a cómo el piloto cargue fechas o páginas.
- Depende del PR de backend: hasta que la migración corra en prod, created_at llega null y el comportamiento no empeora (sigue como está hoy).