### PR TITLE
Release/0.25.0

### DIFF
--- a/lib/features/logbook/data/models/daily_logbook_model.dart
+++ b/lib/features/logbook/data/models/daily_logbook_model.dart
@@ -13,6 +13,7 @@ class DailyLogbookModel extends DailyLogbookEntity {
     super.tailNumberId,
     super.tailNumber,
     super.crewRole,
+    super.createdAt,
   });
 
   /// Factory constructor to create DailyLogbookModel from JSON
@@ -37,6 +38,7 @@ class DailyLogbookModel extends DailyLogbookEntity {
       tailNumberId: json['tail_number_id']?.toString(),
       tailNumber: json['tail_number']?.toString(),
       crewRole: json['crew_role']?.toString(),
+      createdAt: _parseDate(json['created_at']),
     );
   }
 

--- a/lib/features/logbook/domain/entities/daily_logbook_entity.dart
+++ b/lib/features/logbook/domain/entities/daily_logbook_entity.dart
@@ -14,6 +14,8 @@ class DailyLogbookEntity extends Equatable {
   final String? tailNumber; // Denormalized plate, for display
   final String?
   crewRole; // Default crew role for every flight in this book page (editable per flight)
+  final DateTime?
+  createdAt; // DB-assigned creation timestamp, not editable by the pilot
 
   const DailyLogbookEntity({
     required this.id,
@@ -25,6 +27,7 @@ class DailyLogbookEntity extends Equatable {
     this.tailNumberId,
     this.tailNumber,
     this.crewRole,
+    this.createdAt,
   });
 
   /// Returns a display-friendly logbook ID
@@ -78,5 +81,6 @@ class DailyLogbookEntity extends Equatable {
     tailNumberId,
     tailNumber,
     crewRole,
+    createdAt,
   ];
 }

--- a/lib/features/logbook/presentation/pages/logbook_page.dart
+++ b/lib/features/logbook/presentation/pages/logbook_page.dart
@@ -1395,19 +1395,26 @@ class _LogbookPageState extends State<LogbookPage> {
   }
 
   /// Returns the crew_role of the most recently created bitácora, skipping
-  /// any with no crew_role set. `daily_logbook` rows come sorted newest-first
-  /// from the backend (`ORDER BY log_date DESC`), so the first match is the
-  /// role to default to — this reads directly off the bitácora header field
-  /// the pilot picks on this very form, so it updates the instant a new
-  /// bitácora is created, even before any flight is logged under it.
+  /// any with no crew_role set. The backend sorts `daily_logbook` rows by
+  /// `log_date DESC`, but log_date is the calendar date the pilot picked for
+  /// that book page — not a creation timestamp — so a bitácora logged out of
+  /// date order (e.g. catching up on an earlier flight) can sort ahead of
+  /// one created afterward. `book_page` increases monotonically as bitácoras
+  /// are created (it's the same signal the auto-increment above relies on),
+  /// so it's the reliable "most recent" indicator here, not list order.
   String? _lastCrewRoleFrom(List<DailyLogbookEntity> logbooks) {
+    DailyLogbookEntity? latest;
     for (final logbook in logbooks) {
-      if (logbook.crewRole != null &&
-          _newLogbookCrewRoles.contains(logbook.crewRole)) {
-        return logbook.crewRole;
+      if (logbook.crewRole == null ||
+          !_newLogbookCrewRoles.contains(logbook.crewRole)) {
+        continue;
+      }
+      if (latest == null ||
+          (logbook.bookPage ?? -1) > (latest.bookPage ?? -1)) {
+        latest = logbook;
       }
     }
-    return null;
+    return latest?.crewRole;
   }
 
   /// Show the create logbook form dialog

--- a/lib/features/logbook/presentation/pages/logbook_page.dart
+++ b/lib/features/logbook/presentation/pages/logbook_page.dart
@@ -1,7 +1,4 @@
 import 'package:flight_hours_app/core/responsive/responsive_padding.dart';
-import 'package:flight_hours_app/features/flight_summary/presentation/bloc/flight_summary_bloc.dart';
-import 'package:flight_hours_app/features/flight_summary/presentation/bloc/flight_summary_event.dart';
-import 'package:flight_hours_app/features/flight_summary/presentation/bloc/flight_summary_state.dart';
 import 'package:flight_hours_app/features/logbook/domain/entities/daily_logbook_entity.dart';
 import 'package:flight_hours_app/features/logbook/domain/entities/logbook_detail_entity.dart';
 import 'package:flight_hours_app/features/logbook/presentation/bloc/logbook_bloc.dart';
@@ -1397,15 +1394,17 @@ class _LogbookPageState extends State<LogbookPage> {
     );
   }
 
-  /// Returns the crew_role of the most recently saved flight, skipping any
-  /// with no crew_role set. Recent flights already come sorted newest-first
-  /// from the backend (see GET /employees/recent-flights).
-  String? _lastCrewRoleFrom(FlightSummaryState state) {
-    if (state is! RecentFlightsSuccess) return null;
-    for (final flight in state.flights) {
-      if (flight.crewRole != null &&
-          _newLogbookCrewRoles.contains(flight.crewRole)) {
-        return flight.crewRole;
+  /// Returns the crew_role of the most recently created bitácora, skipping
+  /// any with no crew_role set. `daily_logbook` rows come sorted newest-first
+  /// from the backend (`ORDER BY log_date DESC`), so the first match is the
+  /// role to default to — this reads directly off the bitácora header field
+  /// the pilot picks on this very form, so it updates the instant a new
+  /// bitácora is created, even before any flight is logged under it.
+  String? _lastCrewRoleFrom(List<DailyLogbookEntity> logbooks) {
+    for (final logbook in logbooks) {
+      if (logbook.crewRole != null &&
+          _newLogbookCrewRoles.contains(logbook.crewRole)) {
+        return logbook.crewRole;
       }
     }
     return null;
@@ -1420,19 +1419,11 @@ class _LogbookPageState extends State<LogbookPage> {
     TailNumberEntity? selectedTailNumber;
     bool isSearchingTailNumber = false;
     bool tailNumberNotFound = false;
+    String? selectedCrewRole;
 
-    // Default Crew Role to whatever the pilot last flew as — pulled from the
-    // recent-flights cache (already loaded at login) so new logbooks don't
+    // Auto-increment book_page + default Crew Role to whatever the pilot
+    // used on their most recently created bitácora, so new logbooks don't
     // start with the field empty every time. Still fully overridable below.
-    final flightSummaryState = context.read<FlightSummaryBloc>().state;
-    String? selectedCrewRole = _lastCrewRoleFrom(flightSummaryState);
-    if (flightSummaryState is! RecentFlightsSuccess) {
-      // Not loaded yet (e.g. bloc was reset) — fetch it and apply the
-      // default once it arrives, via the BlocListener below.
-      context.read<FlightSummaryBloc>().add(LoadRecentFlights());
-    }
-
-    // Auto-increment: find max book_page from existing logbooks
     final state = context.read<LogbookBloc>().state;
     if (state is DailyLogbooksLoaded) {
       int maxPage = 0;
@@ -1442,6 +1433,7 @@ class _LogbookPageState extends State<LogbookPage> {
         }
       }
       bookPageController.text = (maxPage + 1).toString();
+      selectedCrewRole = _lastCrewRoleFrom(state.logbooks);
     }
 
     // Start from a clean slate — the TailNumberBloc is a global singleton
@@ -1453,41 +1445,23 @@ class _LogbookPageState extends State<LogbookPage> {
       builder: (dialogContext) {
         return StatefulBuilder(
           builder: (context, setDialogState) {
-            return MultiBlocListener(
-              listeners: [
-                BlocListener<TailNumberBloc, TailNumberState>(
-                  listener: (context, tailNumberState) {
-                    if (tailNumberState is TailNumberSuccess) {
-                      setDialogState(() {
-                        selectedTailNumber = tailNumberState.tailNumber;
-                        isSearchingTailNumber = false;
-                        tailNumberNotFound = false;
-                      });
-                    } else if (tailNumberState is TailNumberError) {
-                      setDialogState(() {
-                        isSearchingTailNumber = false;
-                        tailNumberNotFound = true;
-                      });
-                    } else if (tailNumberState is TailNumberLoading) {
-                      setDialogState(() => isSearchingTailNumber = true);
-                    }
-                  },
-                ),
-                BlocListener<FlightSummaryBloc, FlightSummaryState>(
-                  listener: (context, flightSummaryState) {
-                    // Applies the last-used-crew-role default if it wasn't
-                    // ready yet when the dialog opened. Only fills the field
-                    // in — never overwrites a role the pilot already picked.
-                    if (selectedCrewRole == null &&
-                        flightSummaryState is RecentFlightsSuccess) {
-                      final lastRole = _lastCrewRoleFrom(flightSummaryState);
-                      if (lastRole != null) {
-                        setDialogState(() => selectedCrewRole = lastRole);
-                      }
-                    }
-                  },
-                ),
-              ],
+            return BlocListener<TailNumberBloc, TailNumberState>(
+              listener: (context, tailNumberState) {
+                if (tailNumberState is TailNumberSuccess) {
+                  setDialogState(() {
+                    selectedTailNumber = tailNumberState.tailNumber;
+                    isSearchingTailNumber = false;
+                    tailNumberNotFound = false;
+                  });
+                } else if (tailNumberState is TailNumberError) {
+                  setDialogState(() {
+                    isSearchingTailNumber = false;
+                    tailNumberNotFound = true;
+                  });
+                } else if (tailNumberState is TailNumberLoading) {
+                  setDialogState(() => isSearchingTailNumber = true);
+                }
+              },
               child: AlertDialog(
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(20),

--- a/lib/features/logbook/presentation/pages/logbook_page.dart
+++ b/lib/features/logbook/presentation/pages/logbook_page.dart
@@ -1395,13 +1395,13 @@ class _LogbookPageState extends State<LogbookPage> {
   }
 
   /// Returns the crew_role of the most recently created bitácora, skipping
-  /// any with no crew_role set. The backend sorts `daily_logbook` rows by
-  /// `log_date DESC`, but log_date is the calendar date the pilot picked for
-  /// that book page — not a creation timestamp — so a bitácora logged out of
-  /// date order (e.g. catching up on an earlier flight) can sort ahead of
-  /// one created afterward. `book_page` increases monotonically as bitácoras
-  /// are created (it's the same signal the auto-increment above relies on),
-  /// so it's the reliable "most recent" indicator here, not list order.
+  /// any with no crew_role set. Neither `log_date` (a calendar date the pilot
+  /// picks freely, including past dates when backfilling a flight) nor
+  /// `book_page` (a physical logbook page code, not a sequential app
+  /// counter) reliably reflects real creation order — both are editable by
+  /// the pilot and can end up "out of order" relative to when a bitácora was
+  /// actually saved. `created_at` is a DB-assigned timestamp the pilot never
+  /// touches, so it's the only field that can't be thrown off this way.
   String? _lastCrewRoleFrom(List<DailyLogbookEntity> logbooks) {
     DailyLogbookEntity? latest;
     for (final logbook in logbooks) {
@@ -1410,7 +1410,9 @@ class _LogbookPageState extends State<LogbookPage> {
         continue;
       }
       if (latest == null ||
-          (logbook.bookPage ?? -1) > (latest.bookPage ?? -1)) {
+          (logbook.createdAt ?? DateTime(0)).isAfter(
+            latest.createdAt ?? DateTime(0),
+          )) {
         latest = logbook;
       }
     }

--- a/lib/features/logbook/presentation/pages/logbook_page.dart
+++ b/lib/features/logbook/presentation/pages/logbook_page.dart
@@ -1,4 +1,7 @@
 import 'package:flight_hours_app/core/responsive/responsive_padding.dart';
+import 'package:flight_hours_app/features/flight_summary/presentation/bloc/flight_summary_bloc.dart';
+import 'package:flight_hours_app/features/flight_summary/presentation/bloc/flight_summary_event.dart';
+import 'package:flight_hours_app/features/flight_summary/presentation/bloc/flight_summary_state.dart';
 import 'package:flight_hours_app/features/logbook/domain/entities/daily_logbook_entity.dart';
 import 'package:flight_hours_app/features/logbook/domain/entities/logbook_detail_entity.dart';
 import 'package:flight_hours_app/features/logbook/presentation/bloc/logbook_bloc.dart';
@@ -1394,6 +1397,20 @@ class _LogbookPageState extends State<LogbookPage> {
     );
   }
 
+  /// Returns the crew_role of the most recently saved flight, skipping any
+  /// with no crew_role set. Recent flights already come sorted newest-first
+  /// from the backend (see GET /employees/recent-flights).
+  String? _lastCrewRoleFrom(FlightSummaryState state) {
+    if (state is! RecentFlightsSuccess) return null;
+    for (final flight in state.flights) {
+      if (flight.crewRole != null &&
+          _newLogbookCrewRoles.contains(flight.crewRole)) {
+        return flight.crewRole;
+      }
+    }
+    return null;
+  }
+
   /// Show the create logbook form dialog
   void _showLogbookFormDialog() {
     final dateController = TextEditingController();
@@ -1403,7 +1420,17 @@ class _LogbookPageState extends State<LogbookPage> {
     TailNumberEntity? selectedTailNumber;
     bool isSearchingTailNumber = false;
     bool tailNumberNotFound = false;
-    String? selectedCrewRole;
+
+    // Default Crew Role to whatever the pilot last flew as — pulled from the
+    // recent-flights cache (already loaded at login) so new logbooks don't
+    // start with the field empty every time. Still fully overridable below.
+    final flightSummaryState = context.read<FlightSummaryBloc>().state;
+    String? selectedCrewRole = _lastCrewRoleFrom(flightSummaryState);
+    if (flightSummaryState is! RecentFlightsSuccess) {
+      // Not loaded yet (e.g. bloc was reset) — fetch it and apply the
+      // default once it arrives, via the BlocListener below.
+      context.read<FlightSummaryBloc>().add(LoadRecentFlights());
+    }
 
     // Auto-increment: find max book_page from existing logbooks
     final state = context.read<LogbookBloc>().state;
@@ -1426,23 +1453,41 @@ class _LogbookPageState extends State<LogbookPage> {
       builder: (dialogContext) {
         return StatefulBuilder(
           builder: (context, setDialogState) {
-            return BlocListener<TailNumberBloc, TailNumberState>(
-              listener: (context, tailNumberState) {
-                if (tailNumberState is TailNumberSuccess) {
-                  setDialogState(() {
-                    selectedTailNumber = tailNumberState.tailNumber;
-                    isSearchingTailNumber = false;
-                    tailNumberNotFound = false;
-                  });
-                } else if (tailNumberState is TailNumberError) {
-                  setDialogState(() {
-                    isSearchingTailNumber = false;
-                    tailNumberNotFound = true;
-                  });
-                } else if (tailNumberState is TailNumberLoading) {
-                  setDialogState(() => isSearchingTailNumber = true);
-                }
-              },
+            return MultiBlocListener(
+              listeners: [
+                BlocListener<TailNumberBloc, TailNumberState>(
+                  listener: (context, tailNumberState) {
+                    if (tailNumberState is TailNumberSuccess) {
+                      setDialogState(() {
+                        selectedTailNumber = tailNumberState.tailNumber;
+                        isSearchingTailNumber = false;
+                        tailNumberNotFound = false;
+                      });
+                    } else if (tailNumberState is TailNumberError) {
+                      setDialogState(() {
+                        isSearchingTailNumber = false;
+                        tailNumberNotFound = true;
+                      });
+                    } else if (tailNumberState is TailNumberLoading) {
+                      setDialogState(() => isSearchingTailNumber = true);
+                    }
+                  },
+                ),
+                BlocListener<FlightSummaryBloc, FlightSummaryState>(
+                  listener: (context, flightSummaryState) {
+                    // Applies the last-used-crew-role default if it wasn't
+                    // ready yet when the dialog opened. Only fills the field
+                    // in — never overwrites a role the pilot already picked.
+                    if (selectedCrewRole == null &&
+                        flightSummaryState is RecentFlightsSuccess) {
+                      final lastRole = _lastCrewRoleFrom(flightSummaryState);
+                      if (lastRole != null) {
+                        setDialogState(() => selectedCrewRole = lastRole);
+                      }
+                    }
+                  },
+                ),
+              ],
               child: AlertDialog(
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(20),

--- a/test/features/logbook/domain/entities/daily_logbook_entity_test.dart
+++ b/test/features/logbook/domain/entities/daily_logbook_entity_test.dart
@@ -136,7 +136,7 @@ void main() {
         status: true,
       );
 
-      expect(entity.props.length, equals(9));
+      expect(entity.props.length, equals(10));
     });
   });
 }


### PR DESCRIPTION
 Fix Crew Role default: use created_at, not book_page/log_date
 Sigue a los PR #61/#62/#63. Pruebas reales mostraron que book_page
  también fallaba como proxy de "creada más recientemente": es un código
  de página física del logbook, no un contador secuencial de la app, así
  que una bitácora vieja puede tener un book_page numéricamente mayor que
  una nueva y seguir ganando la comparación.
- Ahora usa daily_logbook.created_at (agregado en api-flighthours, PR
  companion ya mergeado/desplegado) — timestamp que la base de datos
  asigna sola, inmune a cómo el piloto cargue fechas o números de página.
- Requiere que el backend con la migración ya esté en producción para
  tener efecto (si no, created_at llega null y el comportamiento no
  empeora respecto al estado actual).