### PR TITLE
Release/0.26.0

### DIFF
--- a/lib/features/crew_member/domain/entities/crew_member_entity.dart
+++ b/lib/features/crew_member/domain/entities/crew_member_entity.dart
@@ -1,6 +1,6 @@
 import 'package:equatable/equatable.dart';
 
-/// Represents a person in a pilot's own crew roster (First Officer or cabin
+/// Represents a person in a pilot's own crew roster (command crew or cabin
 /// crew they've flown with before). Scoped per pilot on the backend.
 class CrewMemberEntity extends Equatable {
   final String id;

--- a/lib/features/crew_member/presentation/bloc/crew_member_bloc.dart
+++ b/lib/features/crew_member/presentation/bloc/crew_member_bloc.dart
@@ -6,7 +6,7 @@ import 'package:flight_hours_app/features/crew_member/domain/usecases/search_cre
 import 'package:flight_hours_app/features/crew_member/presentation/bloc/crew_member_event.dart';
 import 'package:flight_hours_app/features/crew_member/presentation/bloc/crew_member_state.dart';
 
-/// BLoC for the authenticated pilot's own crew roster (First Officer + cabin crew)
+/// BLoC for the authenticated pilot's own crew roster (Tripulación de Mando + cabin crew)
 class CrewMemberBloc extends Bloc<CrewMemberEvent, CrewMemberState> {
   final SearchCrewMembersUseCase _searchCrewMembersUseCase;
   final CreateCrewMemberUseCase _createCrewMemberUseCase;

--- a/lib/features/daily_logbook_detail/presentation/pages/daily_logbook_detail_page.dart
+++ b/lib/features/daily_logbook_detail/presentation/pages/daily_logbook_detail_page.dart
@@ -69,8 +69,8 @@ class _DailyLogbookDetailPageState extends State<DailyLogbookDetailPage> {
   bool _initialized = false;
   bool _hasChanges = false; // Tracks if user modified any field
 
-  // Additional crew (First Officer + cabin crew). null = not touched by this
-  // form yet, so it won't overwrite existing crew on save.
+  // Additional crew (Tripulación de Mando + cabin crew). null = not touched
+  // by this form yet, so it won't overwrite existing crew on save.
   final _crewSectionKey = GlobalKey<CrewSectionState>();
   List<Map<String, String>>? _crewPayload;
 
@@ -135,7 +135,7 @@ class _DailyLogbookDetailPageState extends State<DailyLogbookDetailPage> {
         // Landed here right after creating a new flight (new_flight_page.dart
         // pushes this route with only 'detail', no 'logbook' — see
         // _navigateToLogbookDetailForm there). If this daily logbook already
-        // has other flights, offer to reuse their First Officer + cabin crew.
+        // has other flights, offer to reuse their Tripulación de Mando + cabin crew.
         WidgetsBinding.instance.addPostFrameCallback(
           (_) => _maybeOfferKeepCrew(),
         );
@@ -144,7 +144,7 @@ class _DailyLogbookDetailPageState extends State<DailyLogbookDetailPage> {
   }
 
   /// Feature: keep-or-change crew between flights of the same daily logbook.
-  /// Only First Officer + cabin crew are offered — the captain is the pilot
+  /// Only Tripulación de Mando + cabin crew are offered — the captain is the pilot
   /// themselves, unrelated to this prompt.
   Future<void> _maybeOfferKeepCrew() async {
     final dailyLogbookId = _detail?.dailyLogbookId;
@@ -174,7 +174,7 @@ class _DailyLogbookDetailPageState extends State<DailyLogbookDetailPage> {
           (context) => AlertDialog(
             title: const Text('Tripulación'),
             content: const Text(
-              '¿Mantener la tripulación (Primer Oficial y Cabina) del vuelo anterior de esta bitácora?',
+              '¿Mantener la tripulación (Mando y Cabina) del vuelo anterior de esta bitácora?',
             ),
             actions: [
               TextButton(
@@ -473,7 +473,7 @@ class _DailyLogbookDetailPageState extends State<DailyLogbookDetailPage> {
                   ),
                   const SizedBox(height: 16),
 
-                  // ── Additional crew (First Officer + cabin crew) ──
+                  // ── Additional crew (Tripulación de Mando + cabin crew) ──
                   _buildSectionLabel('Tripulación'),
                   const SizedBox(height: 8),
                   CrewSection(

--- a/lib/features/daily_logbook_detail/presentation/widgets/crew_section.dart
+++ b/lib/features/daily_logbook_detail/presentation/widgets/crew_section.dart
@@ -10,12 +10,31 @@ import 'package:flight_hours_app/features/crew_member_type/presentation/bloc/cre
 import 'package:flight_hours_app/features/crew_member_type/presentation/bloc/crew_member_type_state.dart';
 import 'package:flight_hours_app/features/logbook/domain/entities/crew_assignment_entity.dart';
 
-const String kFirstOfficerRole = 'first_officer';
+/// Legacy role value from before the "Tripulación de Mando" redesign — old
+/// flights may still have a row saved with this. Treated as a command crew
+/// row on load (normalized to [kDefaultCommandCrewRole]); no longer written.
+const String kLegacyFirstOfficerRole = 'first_officer';
 
-/// One row in the crew section: either the single "Primer Oficial" slot
-/// (role fixed) or one of the dynamic "Tripulación de cabina" rows (role
-/// pickable from the cabin_crew catalog). A row is either resolved to an
-/// existing roster member ([selected] set, picked from search) or holds a
+/// The 5 command crew role values — same vocabulary as the per-flight Crew
+/// Role field (`daily_logbook_detail.crew_role`). Kept in sync with
+/// `_crewRoles` in `daily_logbook_detail_page.dart`.
+const List<String> kCommandCrewRoles = [
+  'captain',
+  'first officer',
+  'instructor',
+  'line check captain',
+  'safety pilot',
+];
+
+const String kDefaultCommandCrewRole = 'first officer';
+
+bool _isCommandCrewRole(String role) =>
+    role == kLegacyFirstOfficerRole || kCommandCrewRoles.contains(role);
+
+/// One row in the crew section: either a "Tripulación de Mando" row (role
+/// pickable from the 5 crew_role values) or a "Tripulación de cabina" row
+/// (role pickable from the cabin_crew catalog). A row is either resolved to
+/// an existing roster member ([selected] set, picked from search) or holds a
 /// brand-new person's name/BP — resolved/created by the backend in the same
 /// transaction as the flight save, not before.
 class _CrewRow {
@@ -38,13 +57,14 @@ class _CrewRow {
   }
 }
 
-/// Optional "Tripulación" section for the Daily Logbook Detail form: Primer
-/// Oficial (0-1) + Tripulación de cabina (0-N). Each row just needs a name
-/// (typed or picked from a search suggestion) + cargo — nothing is sent to
-/// the backend until the whole flight is saved, at which point every row
-/// (existing people and brand-new ones alike) is persisted together in one
-/// request via [onChanged]'s payload (`crew_member_id` for existing people,
-/// `name`/`bp` for new ones — resolved server-side in the same transaction).
+/// Optional "Tripulación" section for the Daily Logbook Detail form:
+/// Tripulación de Mando (0-N, realistically 2-4) + Tripulación de cabina
+/// (0-N). Each row just needs a name (typed or picked from a search
+/// suggestion) + role — nothing is sent to the backend until the whole
+/// flight is saved, at which point every row (existing people and brand-new
+/// ones alike) is persisted together in one request via [onChanged]'s
+/// payload (`crew_member_id` for existing people, `name`/`bp` for new ones —
+/// resolved server-side in the same transaction).
 class CrewSection extends StatefulWidget {
   final List<CrewAssignmentEntity>? initialCrew;
   final ValueChanged<List<Map<String, String>>> onChanged;
@@ -56,7 +76,7 @@ class CrewSection extends StatefulWidget {
 }
 
 class CrewSectionState extends State<CrewSection> {
-  _CrewRow? _firstOfficerRow;
+  final List<_CrewRow> _commandCrewRows = [];
   final List<_CrewRow> _cabinCrewRows = [];
 
   List<CrewMemberEntity> _roster = [];
@@ -75,7 +95,9 @@ class CrewSectionState extends State<CrewSection> {
 
   @override
   void dispose() {
-    _firstOfficerRow?.dispose();
+    for (final row in _commandCrewRows) {
+      row.dispose();
+    }
     for (final row in _cabinCrewRows) {
       row.dispose();
     }
@@ -91,10 +113,12 @@ class CrewSectionState extends State<CrewSection> {
         name: a.name,
         bp: a.bp,
       );
-      if (a.role == kFirstOfficerRole) {
-        _firstOfficerRow = _CrewRow(role: a.role, selected: member);
+      final role =
+          a.role == kLegacyFirstOfficerRole ? kDefaultCommandCrewRole : a.role;
+      if (_isCommandCrewRole(role)) {
+        _commandCrewRows.add(_CrewRow(role: role, selected: member));
       } else {
-        _cabinCrewRows.add(_CrewRow(role: a.role, selected: member));
+        _cabinCrewRows.add(_CrewRow(role: role, selected: member));
       }
     }
   }
@@ -103,11 +127,13 @@ class CrewSectionState extends State<CrewSection> {
   /// crew from the previous flight"). Replaces whatever is currently set.
   void applyCrew(List<CrewAssignmentEntity> crew) {
     setState(() {
-      _firstOfficerRow?.dispose();
+      for (final row in _commandCrewRows) {
+        row.dispose();
+      }
       for (final row in _cabinCrewRows) {
         row.dispose();
       }
-      _firstOfficerRow = null;
+      _commandCrewRows.clear();
       _cabinCrewRows.clear();
       for (final a in crew) {
         final member = CrewMemberEntity(
@@ -115,10 +141,14 @@ class CrewSectionState extends State<CrewSection> {
           name: a.name,
           bp: a.bp,
         );
-        if (a.role == kFirstOfficerRole) {
-          _firstOfficerRow = _CrewRow(role: a.role, selected: member);
+        final role =
+            a.role == kLegacyFirstOfficerRole
+                ? kDefaultCommandCrewRole
+                : a.role;
+        if (_isCommandCrewRole(role)) {
+          _commandCrewRows.add(_CrewRow(role: role, selected: member));
         } else {
-          _cabinCrewRows.add(_CrewRow(role: a.role, selected: member));
+          _cabinCrewRows.add(_CrewRow(role: role, selected: member));
         }
       }
     });
@@ -128,11 +158,13 @@ class CrewSectionState extends State<CrewSection> {
   /// Clears every row (Feature 2: "start this flight's crew from scratch").
   void clearCrew() {
     setState(() {
-      _firstOfficerRow?.dispose();
+      for (final row in _commandCrewRows) {
+        row.dispose();
+      }
       for (final row in _cabinCrewRows) {
         row.dispose();
       }
-      _firstOfficerRow = null;
+      _commandCrewRows.clear();
       _cabinCrewRows.clear();
     });
     _notifyChange();
@@ -154,8 +186,8 @@ class CrewSectionState extends State<CrewSection> {
 
   void _notifyChange() {
     final payload = <Map<String, String>>[];
-    if (_firstOfficerRow != null) {
-      final entry = _payloadFor(_firstOfficerRow!);
+    for (final row in _commandCrewRows) {
+      final entry = _payloadFor(row);
       if (entry != null) payload.add(entry);
     }
     for (final row in _cabinCrewRows) {
@@ -198,9 +230,13 @@ class CrewSectionState extends State<CrewSection> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          _buildLabel('Primer Oficial (opcional)'),
+          _buildLabel('Tripulación de Mando (opcional)'),
           const SizedBox(height: 8),
-          _buildFirstOfficerRow(),
+          ..._commandCrewRows.map(_buildCommandCrewRow),
+          const SizedBox(height: 8),
+          _buildAddCommandCrewButton(),
+          if (_buildCommandCrewCountWarning() != null)
+            _buildCommandCrewCountWarning()!,
           const SizedBox(height: 20),
           _buildLabel('Tripulación de cabina (opcional)'),
           const SizedBox(height: 8),
@@ -224,9 +260,107 @@ class CrewSectionState extends State<CrewSection> {
     );
   }
 
-  Widget _buildFirstOfficerRow() {
-    _firstOfficerRow ??= _CrewRow(role: kFirstOfficerRole);
-    return _buildPersonPicker(_firstOfficerRow!, showRoleDropdown: false);
+  /// Non-blocking hint shown when the command crew count falls outside the
+  /// realistic range the client described. This list is the OTHER pilots —
+  /// it does not include the bitácora's own owner (whoever picked a role in
+  /// the Crew Role field above). Total aircraft crew is 2-4, so this list
+  /// should realistically hold 1-3 people, not 2-4. Never prevents saving.
+  Widget? _buildCommandCrewCountWarning() {
+    final count = _commandCrewRows.length;
+    if (count == 0 || count <= 3) return null;
+    const message =
+        'Se registraron más de 3 tripulantes de mando adicionales al titular de la bitácora — verifica que sea correcto.';
+    return Padding(
+      padding: const EdgeInsets.only(top: 4, bottom: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(Icons.info_outline, size: 14, color: Color(0xFFf0a020)),
+          const SizedBox(width: 4),
+          Expanded(
+            child: Text(
+              message,
+              style: const TextStyle(color: Color(0xFFf0a020), fontSize: 12),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCommandCrewRow(_CrewRow row) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: _buildPersonPicker(
+              row,
+              roleDropdownBuilder: _buildCommandRoleDropdown,
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.close, color: Color(0xFF6c757d), size: 20),
+            tooltip: 'Quitar',
+            onPressed: () {
+              setState(() {
+                row.dispose();
+                _commandCrewRows.remove(row);
+              });
+              _notifyChange();
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAddCommandCrewButton() {
+    return OutlinedButton.icon(
+      onPressed: () {
+        setState(
+          () => _commandCrewRows.add(_CrewRow(role: kDefaultCommandCrewRole)),
+        );
+      },
+      icon: const Icon(Icons.add, size: 18),
+      label: const Text('Agregar tripulante de mando'),
+      style: OutlinedButton.styleFrom(
+        foregroundColor: const Color(0xFF4facfe),
+        side: const BorderSide(color: Color(0xFF4facfe)),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      ),
+    );
+  }
+
+  Widget _buildCommandRoleDropdown(_CrewRow row) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF5F5F5),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: DropdownButtonHideUnderline(
+        child: DropdownButton<String>(
+          value: kCommandCrewRoles.contains(row.role) ? row.role : null,
+          isDense: true,
+          items:
+              kCommandCrewRoles
+                  .map(
+                    (r) => DropdownMenuItem(
+                      value: r,
+                      child: Text(r, style: const TextStyle(fontSize: 13)),
+                    ),
+                  )
+                  .toList(),
+          onChanged: (value) {
+            if (value == null) return;
+            setState(() => row.role = value);
+            _notifyChange();
+          },
+        ),
+      ),
+    );
   }
 
   Widget _buildCabinCrewRow(_CrewRow row) {
@@ -235,7 +369,12 @@ class CrewSectionState extends State<CrewSection> {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Expanded(child: _buildPersonPicker(row, showRoleDropdown: true)),
+          Expanded(
+            child: _buildPersonPicker(
+              row,
+              roleDropdownBuilder: _buildCabinRoleDropdown,
+            ),
+          ),
           IconButton(
             icon: const Icon(Icons.close, color: Color(0xFF6c757d), size: 20),
             tooltip: 'Quitar',
@@ -278,7 +417,7 @@ class CrewSectionState extends State<CrewSection> {
   /// "cabin-flight_attendant" — the suffix IS the role code this form sends.
   String _roleCodeFromCatalogId(String id) => id.replaceFirst('cabin-', '');
 
-  Widget _buildRoleDropdown(_CrewRow row) {
+  Widget _buildCabinRoleDropdown(_CrewRow row) {
     if (_cabinCrewTypes.isEmpty) {
       return const SizedBox(
         height: 20,
@@ -318,9 +457,12 @@ class CrewSectionState extends State<CrewSection> {
     );
   }
 
-  Widget _buildPersonPicker(_CrewRow row, {required bool showRoleDropdown}) {
+  Widget _buildPersonPicker(
+    _CrewRow row, {
+    required Widget Function(_CrewRow row) roleDropdownBuilder,
+  }) {
     if (row.selected != null) {
-      return _buildSelectedChip(row, showRoleDropdown: showRoleDropdown);
+      return _buildSelectedChip(row, roleDropdownBuilder: roleDropdownBuilder);
     }
 
     final query = row.query.toLowerCase();
@@ -334,10 +476,8 @@ class CrewSectionState extends State<CrewSection> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (showRoleDropdown) ...[
-          _buildRoleDropdown(row),
-          const SizedBox(height: 8),
-        ],
+        roleDropdownBuilder(row),
+        const SizedBox(height: 8),
         Container(
           decoration: BoxDecoration(
             color: const Color(0xFFF5F5F5),
@@ -461,14 +601,15 @@ class CrewSectionState extends State<CrewSection> {
     );
   }
 
-  Widget _buildSelectedChip(_CrewRow row, {required bool showRoleDropdown}) {
+  Widget _buildSelectedChip(
+    _CrewRow row, {
+    required Widget Function(_CrewRow row) roleDropdownBuilder,
+  }) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (showRoleDropdown) ...[
-          _buildRoleDropdown(row),
-          const SizedBox(height: 8),
-        ],
+        roleDropdownBuilder(row),
+        const SizedBox(height: 8),
         Container(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
           decoration: BoxDecoration(

--- a/lib/features/logbook/data/models/logbook_detail_model.dart
+++ b/lib/features/logbook/data/models/logbook_detail_model.dart
@@ -105,7 +105,7 @@ class LogbookDetailModel extends LogbookDetailEntity {
     );
   }
 
-  /// Parses the `crew` array (First Officer + cabin crew) from a detail response.
+  /// Parses the `crew` array (Tripulación de Mando + cabin crew) from a detail response.
   /// Returns null if the key is absent (vs. an empty list if present-but-empty).
   static List<CrewAssignmentEntity>? _parseCrew(dynamic value) {
     if (value is! List) return null;

--- a/lib/features/logbook/domain/entities/crew_assignment_entity.dart
+++ b/lib/features/logbook/domain/entities/crew_assignment_entity.dart
@@ -1,14 +1,17 @@
 import 'package:equatable/equatable.dart';
 
-/// One First Officer/cabin crew assignment on a flight leg.
-/// The captain is NOT represented here — that's the logged-in pilot
-/// themselves, already covered by [LogbookDetailEntity.pilotRole]/companion.
+/// One command crew/cabin crew assignment on a flight leg.
+/// The logged-in pilot is NOT represented here — their own role is
+/// [LogbookDetailEntity.crewRole].
 class CrewAssignmentEntity extends Equatable {
   final String id;
   final String crewMemberId;
   final String name;
   final String? bp;
-  final String role; // first_officer, purser, flight_attendant
+  // Command crew: captain, first officer, instructor, line check captain,
+  // safety pilot (see kCommandCrewRoles in crew_section.dart). Cabin crew:
+  // purser, flight_attendant. Legacy rows may still say first_officer.
+  final String role;
 
   const CrewAssignmentEntity({
     this.id = '',

--- a/lib/features/logbook/domain/entities/logbook_detail_entity.dart
+++ b/lib/features/logbook/domain/entities/logbook_detail_entity.dart
@@ -46,7 +46,7 @@ class LogbookDetailEntity extends Equatable {
   final bool? autoland; // only meaningful when approachCategory is ILS
   final String? flightType; // Comercial, Training, etc.
 
-  // Additional crew (First Officer + cabin crew). Null means "not sent by the
+  // Additional crew (Tripulación de Mando + cabin crew). Null means "not sent by the
   // API / not touched by this form submission" — distinct from an empty list,
   // which means "explicitly no additional crew for this flight".
   final List<CrewAssignmentEntity>? crew;

--- a/lib/features/logbook/presentation/bloc/logbook_event.dart
+++ b/lib/features/logbook/presentation/bloc/logbook_event.dart
@@ -136,7 +136,7 @@ class UpdateLogbookDetailEvent extends LogbookEvent {
   final String? approachSubtype;
   final bool? autoland;
   final String? flightType;
-  // First Officer + cabin crew. null = don't touch; [] = clear.
+  // Tripulación de Mando + cabin crew. null = don't touch; [] = clear.
   final List<Map<String, String>>? crew;
 
   const UpdateLogbookDetailEvent({

--- a/test/features/daily_logbook_detail/presentation/pages/daily_logbook_detail_page_test.dart
+++ b/test/features/daily_logbook_detail/presentation/pages/daily_logbook_detail_page_test.dart
@@ -149,4 +149,95 @@ void main() {
       );
     },
   );
+
+  testWidgets(
+    'Tripulación de Mando is a repeatable list (not a fixed Primer Oficial '
+    'slot), each row offers all 5 crew roles, and cabin crew is untouched',
+    (tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pumpAndSettle();
+
+      // New section label present, old fixed-slot label gone.
+      expect(find.text('TRIPULACIÓN DE MANDO (OPCIONAL)'), findsOneWidget);
+      expect(find.text('PRIMER OFICIAL (OPCIONAL)'), findsNothing);
+      // Cabin crew section is untouched by the redesign.
+      expect(find.text('TRIPULACIÓN DE CABINA (OPCIONAL)'), findsOneWidget);
+      expect(find.text('Agregar tripulante de cabina'), findsOneWidget);
+
+      // Starts with zero rows — add two, like the client's real 2-4 person crew.
+      final addCommandCrewButton = find.text('Agregar tripulante de mando');
+      expect(addCommandCrewButton, findsOneWidget);
+      await tester.ensureVisible(addCommandCrewButton);
+      await tester.tap(addCommandCrewButton);
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(addCommandCrewButton);
+      await tester.tap(addCommandCrewButton);
+      await tester.pumpAndSettle();
+
+      // Two rows, each with a name search field and a BP field.
+      expect(find.text('Nombre del tripulante'), findsNWidgets(2));
+      expect(find.text('BP (opcional)'), findsNWidgets(2));
+
+      // Both rows default to 'first officer' and offer all 5 crew_role values.
+      expect(find.text('first officer'), findsNWidgets(2));
+      final roleDropdown = find.byType(DropdownButton<String>).first;
+      await tester.ensureVisible(roleDropdown);
+      await tester.tap(roleDropdown);
+      await tester.pumpAndSettle();
+      for (final role in [
+        'captain',
+        'instructor',
+        'line check captain',
+        'safety pilot',
+      ]) {
+        expect(find.text(role), findsOneWidget);
+      }
+      // Pick 'captain' for the first row (closes the menu without error).
+      final captainMenuItem = find.text('captain').last;
+      await tester.ensureVisible(captainMenuItem);
+      await tester.tap(captainMenuItem);
+      await tester.pumpAndSettle();
+
+      // This list is the OTHER pilots — it does NOT include the bitácora
+      // owner (whoever picked a role in Crew Role above). With 2 rows here
+      // (owner + 2 = 3 total, within 2-4), no count warning is shown.
+      expect(find.textContaining('tripulantes de mando adicionales'), findsNothing);
+
+      // Add two more rows: 4 others + the owner = 5 total, over the limit —
+      // the non-blocking warning appears.
+      await tester.ensureVisible(addCommandCrewButton);
+      await tester.tap(addCommandCrewButton);
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(addCommandCrewButton);
+      await tester.tap(addCommandCrewButton);
+      await tester.pumpAndSettle();
+      expect(
+        find.text(
+          'Se registraron más de 3 tripulantes de mando adicionales al titular de la bitácora — verifica que sea correcto.',
+        ),
+        findsOneWidget,
+      );
+
+      // Removing one row brings it back to 3 others (owner + 3 = 4 total,
+      // still within range) — the warning goes away again.
+      final closeIcon = find.byIcon(Icons.close).first;
+      await tester.ensureVisible(closeIcon);
+      await tester.tap(closeIcon);
+      await tester.pumpAndSettle();
+      expect(find.textContaining('tripulantes de mando adicionales'), findsNothing);
+
+      // Finally, confirm the name/BP fields actually accept input (typing
+      // opens the roster suggestion box, so no pumpAndSettle after this —
+      // its loading spinner never resolves in this mocked-bloc test setup).
+      final nameField = find.widgetWithText(TextField, 'Nombre del tripulante').at(0);
+      await tester.ensureVisible(nameField);
+      await tester.enterText(nameField, 'Ana Captain');
+      final bpField = find.widgetWithText(TextField, 'BP (opcional)').at(0);
+      await tester.ensureVisible(bpField);
+      await tester.enterText(bpField, '1001');
+      await tester.pump();
+      expect(find.text('Ana Captain'), findsOneWidget);
+      expect(find.text('1001'), findsOneWidget);
+    },
+  );
 }


### PR DESCRIPTION
 Replace fixed First Officer slot with repeatable "Tripulación de Mando" list
Resumen:
- CrewSection ahora tiene dos listas repetibles: "Tripulación de Mando" (antes era un slot fijo de "Primer Oficial") y "Tripulación de cabina" (sin cambios). Cada tripulante de mando lleva nombre (buscar existente o crear nuevo), BP, y uno de los 5 roles de Crew Role.
- Aviso visual no bloqueante si la lista de Tripulación de Mando tiene más de 3 personas — esa lista es aparte del dueño de la bitácora (que ya tiene su rol en el campo Crew Role de arriba), así que el total de la aeronave es dueño + hasta 3 más = máximo 4.
- Labels y comentarios actualizados en toda la feature de logbook/crew.
- Depende del PR de backend correspondiente para que el guardado funcione (el backend valida role contra un JSON Schema y un enum de MySQL que también se ampliaron ahí).

Test plan:
- flutter analyze limpio.
- Test de widget nuevo que monta la pantalla real, agrega/quita filas de Tripulación de Mando, abre el dropdown de rol y confirma los 5 valores, y verifica que el aviso aparece/desaparece correctamente con el umbral de 3 — pasa.
- Suite completa de tests de logbook/crew_member/daily_logbook_detail sin regresiones.
- Probado manualmente end-to-end contra el backend local — guardado exitoso, aviso visual funcionando como se esperaba.