### PR TITLE
Release/0.27.0

### DIFF
--- a/lib/features/crew_member/data/datasources/crew_member_remote_data_source.dart
+++ b/lib/features/crew_member/data/datasources/crew_member_remote_data_source.dart
@@ -7,8 +7,10 @@ abstract class CrewMemberRemoteDataSource {
   /// GET /crew-members?search= — the pilot's own roster, optionally filtered by name
   Future<List<CrewMemberModel>> getCrewMembers({String? search});
 
-  /// POST /crew-members — adds a person, or returns the existing match by name
-  Future<CrewMemberModel> createCrewMember(String name);
+  /// POST /crew-members — adds a person, or returns the existing match by name.
+  /// If bp is provided and the matched person doesn't have one on record yet,
+  /// the backend fills it in (never overwrites an existing bp).
+  Future<CrewMemberModel> createCrewMember(String name, {String? bp});
 }
 
 /// Implementation using Dio HTTP client
@@ -37,8 +39,11 @@ class CrewMemberRemoteDataSourceImpl implements CrewMemberRemoteDataSource {
   }
 
   @override
-  Future<CrewMemberModel> createCrewMember(String name) async {
-    final response = await _dio.post('/crew-members', data: {'name': name});
+  Future<CrewMemberModel> createCrewMember(String name, {String? bp}) async {
+    final response = await _dio.post(
+      '/crew-members',
+      data: {'name': name, if (bp != null && bp.isNotEmpty) 'bp': bp},
+    );
     final data = response.data;
 
     if (data is Map<String, dynamic> && data['data'] is Map<String, dynamic>) {

--- a/lib/features/crew_member/data/repositories/crew_member_repository_impl.dart
+++ b/lib/features/crew_member/data/repositories/crew_member_repository_impl.dart
@@ -26,10 +26,11 @@ class CrewMemberRepositoryImpl implements CrewMemberRepository {
 
   @override
   Future<Either<Failure, CrewMemberEntity>> createCrewMember(
-    String name,
-  ) async {
+    String name, {
+    String? bp,
+  }) async {
     try {
-      final member = await _remoteDataSource.createCrewMember(name);
+      final member = await _remoteDataSource.createCrewMember(name, bp: bp);
       return Right(member);
     } catch (e) {
       return Left(_handleError(e));

--- a/lib/features/crew_member/domain/repositories/crew_member_repository.dart
+++ b/lib/features/crew_member/domain/repositories/crew_member_repository.dart
@@ -9,6 +9,11 @@ abstract class CrewMemberRepository {
     String? search,
   });
 
-  /// Add a person to the roster, or return the existing match by name
-  Future<Either<Failure, CrewMemberEntity>> createCrewMember(String name);
+  /// Add a person to the roster, or return the existing match by name.
+  /// If bp is provided and the matched person doesn't have one on record yet,
+  /// the backend fills it in (never overwrites an existing bp).
+  Future<Either<Failure, CrewMemberEntity>> createCrewMember(
+    String name, {
+    String? bp,
+  });
 }

--- a/lib/features/crew_member/domain/usecases/create_crew_member_use_case.dart
+++ b/lib/features/crew_member/domain/usecases/create_crew_member_use_case.dart
@@ -10,7 +10,7 @@ class CreateCrewMemberUseCase {
   CreateCrewMemberUseCase({required CrewMemberRepository repository})
     : _repository = repository;
 
-  Future<Either<Failure, CrewMemberEntity>> call(String name) {
-    return _repository.createCrewMember(name);
+  Future<Either<Failure, CrewMemberEntity>> call(String name, {String? bp}) {
+    return _repository.createCrewMember(name, bp: bp);
   }
 }

--- a/lib/features/crew_member/presentation/bloc/crew_member_bloc.dart
+++ b/lib/features/crew_member/presentation/bloc/crew_member_bloc.dart
@@ -50,7 +50,7 @@ class CrewMemberBloc extends Bloc<CrewMemberEvent, CrewMemberState> {
   ) async {
     emit(const CrewMemberLoading());
 
-    final result = await _createCrewMemberUseCase.call(event.name);
+    final result = await _createCrewMemberUseCase.call(event.name, bp: event.bp);
     result.fold(
       (failure) =>
           emit(CrewMemberError('Failed to add crew member: ${failure.message}')),

--- a/lib/features/crew_member/presentation/bloc/crew_member_event.dart
+++ b/lib/features/crew_member/presentation/bloc/crew_member_event.dart
@@ -18,12 +18,15 @@ class FetchCrewMembers extends CrewMemberEvent {
   List<Object?> get props => [search];
 }
 
-/// Adds a new person to the roster (or resolves to the existing match by name)
+/// Adds a new person to the roster (or resolves to the existing match by
+/// name). If bp is given and the matched person has none on record, it's
+/// filled in — an existing bp is never overwritten.
 class CreateCrewMember extends CrewMemberEvent {
   final String name;
+  final String? bp;
 
-  const CreateCrewMember(this.name);
+  const CreateCrewMember(this.name, {this.bp});
 
   @override
-  List<Object?> get props => [name];
+  List<Object?> get props => [name, bp];
 }

--- a/lib/features/daily_logbook_detail/presentation/widgets/crew_section.dart
+++ b/lib/features/daily_logbook_detail/presentation/widgets/crew_section.dart
@@ -208,6 +208,18 @@ class CrewSectionState extends State<CrewSection> {
                 _roster = state.members;
                 _isLoadingRoster = false;
               });
+            } else if (state is CrewMemberCreated) {
+              // A row's BP was just filled in on the roster (see _saveBpForRow) —
+              // reflect it on the matching row(s) so the field switches from
+              // editable to the read-only display.
+              setState(() {
+                _roster = state.members;
+                for (final row in [..._commandCrewRows, ..._cabinCrewRows]) {
+                  if (row.selected?.id == state.member.id) {
+                    row.selected = state.member;
+                  }
+                }
+              });
             } else if (state is CrewMemberError) {
               setState(() => _isLoadingRoster = false);
               ScaffoldMessenger.of(context).showSnackBar(
@@ -616,37 +628,100 @@ class CrewSectionState extends State<CrewSection> {
             color: const Color(0xFFF5F5F5),
             borderRadius: BorderRadius.circular(12),
           ),
-          child: Row(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Expanded(
-                child: Text(
-                  row.selected!.name,
-                  style: const TextStyle(
-                    fontWeight: FontWeight.w600,
-                    fontSize: 14,
-                    color: Color(0xFF1a1a2e),
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      row.selected!.name,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.w600,
+                        fontSize: 14,
+                        color: Color(0xFF1a1a2e),
+                      ),
+                    ),
                   ),
-                ),
+                  InkWell(
+                    onTap: () {
+                      setState(() {
+                        row.selected = null;
+                        row.searchController.clear();
+                        row.bpController.clear();
+                      });
+                      _notifyChange();
+                    },
+                    child: const Icon(
+                      Icons.close,
+                      size: 18,
+                      color: Color(0xFF6c757d),
+                    ),
+                  ),
+                ],
               ),
-              InkWell(
-                onTap: () {
-                  setState(() {
-                    row.selected = null;
-                    row.searchController.clear();
-                    row.bpController.clear();
-                  });
-                  _notifyChange();
-                },
-                child: const Icon(
-                  Icons.close,
-                  size: 18,
-                  color: Color(0xFF6c757d),
-                ),
-              ),
+              const SizedBox(height: 6),
+              _buildSelectedBp(row),
             ],
           ),
         ),
       ],
     );
+  }
+
+  /// BP for an already-picked roster member: read-only display if it's on
+  /// record; an inline editable field if not, saved to the roster (not the
+  /// flight) as soon as the field loses focus — see [_saveBpForRow].
+  Widget _buildSelectedBp(_CrewRow row) {
+    final bp = row.selected!.bp;
+    if (bp != null && bp.isNotEmpty) {
+      return Row(
+        children: [
+          const Icon(Icons.badge_outlined, size: 14, color: Color(0xFF6c757d)),
+          const SizedBox(width: 4),
+          Text(
+            'BP: $bp',
+            style: const TextStyle(color: Color(0xFF6c757d), fontSize: 12),
+          ),
+        ],
+      );
+    }
+    return Row(
+      children: [
+        const Icon(Icons.badge_outlined, size: 14, color: Color(0xFF6c757d)),
+        const SizedBox(width: 4),
+        Expanded(
+          child: Focus(
+            onFocusChange: (hasFocus) {
+              if (!hasFocus) _saveBpForRow(row);
+            },
+            child: TextField(
+              controller: row.bpController,
+              keyboardType: TextInputType.number,
+              onSubmitted: (_) => _saveBpForRow(row),
+              style: const TextStyle(fontSize: 12),
+              decoration: const InputDecoration(
+                isDense: true,
+                isCollapsed: true,
+                hintText: 'BP (agregar)',
+                hintStyle: TextStyle(color: Color(0xFF6c757d), fontSize: 12),
+                border: InputBorder.none,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// Persists a BP typed for an already-picked roster member who didn't have
+  /// one — reuses the roster's add-crew-member endpoint, which fills bp in
+  /// only when the matched person doesn't already have one on record.
+  void _saveBpForRow(_CrewRow row) {
+    final member = row.selected;
+    if (member == null) return;
+    final bp = row.bpController.text.trim();
+    if (bp.isEmpty || bp == member.bp) return;
+    context.read<CrewMemberBloc>().add(CreateCrewMember(member.name, bp: bp));
   }
 }


### PR DESCRIPTION
Show and allow saving crew BP code in Daily Logbook Detail crew section
Se pidió mostrar el código BP de cualquier tripulante (mando o
cabina) en la pantalla Daily Logbook Detail: si ya está guardado en su
perfil del roster, mostrarlo; si no, permitir agregarlo y guardarlo.

Antes, al seleccionar un tripulante ya existente en el roster
(búsqueda por nombre), el chip solo mostraba el nombre — el BP
guardado nunca se renderizaba, y no había forma de completarlo si
faltaba. Para tripulantes nuevos (texto libre) el campo BP ya existía
y funcionaba sin cambios.

- crew_section.dart: el chip de un tripulante seleccionado ahora
  muestra "BP: <valor>" en modo lectura si ya está guardado, o un
  campo editable "BP (agregar)" si no lo está. Al perder el foco (o
  Enter) con el roster ya seleccionado, se guarda vía
  CreateCrewMember(name, bp) — el mismo endpoint que ya usa el flujo
  de "agregar tripulante nuevo".
- Se agregó el parámetro opcional bp a lo largo de toda la cadena de
  creación del roster (datasource → repository → use case → bloc
  event) para poder mandarlo en esa llamada.
- Sin cambios de backend: POST /crew-members ya resolvía esto de forma
  segura (ON DUPLICATE KEY UPDATE bp = COALESCE(bp, VALUES(bp))) — solo
  rellena el BP si el tripulante no tenía uno, nunca lo sobreescribe.
  En producción el código del backend queda igual.

Probado manualmente contra DB local: tripulante nuevo con BP,
tripulante existente sin BP (se completa y persiste), tripulante
existente con BP ya guardado (se muestra de solo lectura).